### PR TITLE
Added an error message in case of a missing player

### DIFF
--- a/wmal/engine.py
+++ b/wmal/engine.py
@@ -509,7 +509,7 @@ class Engine:
                 try:
                     subprocess.call([self.config['player'], filename])
                 except OSError:
-                    raise utils.EngineError('Player not found.')
+                    raise utils.EngineError('Player not found, check your config.json')
                 self.playing = False
                 return playep
             else:


### PR DESCRIPTION
I mistakenly tried to play a file without setting the default player in the config file to one that I have installed, which lead to the following crash.

```
MyAnimeList Watching> play "Fantasista Doll" 
Engine: Searching for Fantasista Doll 9...
Engine: Found. Starting player...
Traceback (most recent call last):
  File "/usr/bin/wmal", line 9, in <module>
    wmal.ui.cli.main()
  File "/usr/lib/python2.7/site-packages/wmal/ui/cli.py", line 523, in main
    main_cmd.cmdloop()
  File "/usr/lib/python2.7/cmd.py", line 142, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python2.7/cmd.py", line 221, in onecmd
    return func(arg)
  File "/usr/lib/python2.7/site-packages/wmal/ui/cli.py", line 232, in do_play
    played_episode = self.engine.play_episode(show, episode)
  File "/usr/lib/python2.7/site-packages/wmal/engine.py", line 509, in play_episode
    subprocess.call([self.config['player'], filename])
  File "/usr/lib/python2.7/subprocess.py", line 524, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 711, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1308, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
Engine: Unloading...
Data: Unloading...
Data: No items in queue.
Data: Saving metadata...
```

Now it looks like this.

```
Initializing engine...
Engine: Version v0.2
Engine: Reading config files...
Data: Version v0.2
libmal: Version v0.2
Data: Using libmal (anime)
Data: Locking database...
Data: Reading metadata...
Data: Reading queue...
Data: Reading cache...

Ready. Type 'help' for a list of commands.
Press tab for autocompletion and up/down for command history.

MyAnimeList Watching> play "Fantasista Doll" 
Engine: Searching for Fantasista Doll 9...
Engine: Found. Starting player...
<class 'wmal.utils.EngineError'>: Player not found, check your config.json
MyAnimeList Watching> 
```
