### PR TITLE
Added an additional check for PIL, in case the Pillow fork is installed.

### DIFF
--- a/wmal/ui/gtkui.py
+++ b/wmal/ui/gtkui.py
@@ -39,7 +39,7 @@ except ImportError:
         from PIL import Image
         imaging_available = True
     except ImportError:
-        print "Warning: PIL library isn't available. Preview images will be disabled."
+        print "Warning: PIL or Pillow isn't available. Preview images will be disabled."
         imaging_available = False
 
 import wmal.messenger as messenger


### PR DESCRIPTION
Python Pillow is a fork of the inactive Python Image Libraries, recently adopted by Arch Linux as their python2-imaging replacement. 

Because Pillow doesn't use the same global name space as PIL, I've added an additional check once importing 'Image' fails, which checks if Pillow is installed instead, before disabling preview images all together. 

Edit: sorry about the double commit, first pull request so I'm still learning.
