### PR TITLE
Make Qt interface play the next episode instead of the current one

### DIFF
--- a/wmal/ui/qtui.py
+++ b/wmal/ui/qtui.py
@@ -552,9 +552,6 @@ class wmal(QtGui.QMainWindow):
             episode = self.show_progress.value() + 1
             if not play_next:
                 episode = self.show_progress.value()
-            
-            print episode
-            print play_next
 
             self._busy(False)
             self.worker_call('play_episode', self.r_played, show, episode)


### PR DESCRIPTION
I'm not sure whether this is any good, but with the old code the second argument was actually passed to the connect function, which is why `play_next` would be always false. Also, the `episode` wasn't set properly, I guess. 
