### PR TITLE
fixes #73

### DIFF
--- a/wmal/ui/cli.py
+++ b/wmal/ui/cli.py
@@ -98,8 +98,7 @@ class wmal_cmd(cmd.Cmd):
         """
         # Query the engine for the available statuses
         # that the user can choose
-        
-        if arg:
+        if self.parse_args(arg):
             try:
                 args = self.parse_args(arg)
                 self.filter_num = self._guess_status(args[0].lower())
@@ -128,7 +127,7 @@ class wmal_cmd(cmd.Cmd):
         
         Usage: mediatype [mediatype]
         """
-        if arg:
+        if self.parse_args(arg):
             args = self.parse_args(arg)
             if args[0] in self.engine.api_info['supported_mediatypes']:
                 self.engine.reload(mediatype=args[0])
@@ -221,7 +220,7 @@ class wmal_cmd(cmd.Cmd):
         Usage: delete <show id or title>
         
         """
-        if(arg):
+        if self.parse_args(arg):
             args = self.parse_args(arg)
             
             try:
@@ -240,7 +239,7 @@ class wmal_cmd(cmd.Cmd):
             print show['title']
         
     def do_play(self, arg):
-        if arg:
+        if self.parse_args(arg):
             try:
                 args = self.parse_args(arg)
                 show = self.engine.get_show_info_title(args[0])
@@ -275,7 +274,7 @@ class wmal_cmd(cmd.Cmd):
         
         Usage: update <show id or name> <episode number>
         """
-        if arg:
+        if self.parse_args(arg):
             args = self.parse_args(arg)
             try:
                 show = self.engine.get_show_info_title(args[0])
@@ -293,7 +292,7 @@ class wmal_cmd(cmd.Cmd):
         
         Usage: update <show id or name> <score>
         """
-        if arg:
+        if self.parse_args(arg):
             args = self.parse_args(arg)
             try:
                 self.engine.set_score(args[0], args[1])
@@ -310,7 +309,7 @@ class wmal_cmd(cmd.Cmd):
         
         Usage: status <show id or name> <status name>
         """
-        if arg:
+        if self.parse_args(arg):
             args = self.parse_args(arg)
             try:
                 _showname = args[0]


### PR DESCRIPTION
This should solve any crashes with invalid args such as "filter !!!!". It presents the message of "missing arguments" instead of something more specific, but it's not like it will cause confusion, unless an anime named "!!?!?!" is made it should be clear that this is invalid input.
