### PR TITLE
Added show indexes to cli for easier playing of episodes

### DIFF
--- a/wmal/ui/cli.py
+++ b/wmal/ui/cli.py
@@ -240,12 +240,17 @@ class wmal_cmd(cmd.Cmd):
         
     def do_play(self, arg):
         try: # Attempt parsing as list index
-            numb = int(arg)
-            if numb < len(self.list_indexes):
-                self.do_play('"{}"'.format(self.list_indexes[numb]))
+            args = self.parse_args(arg)
+            index = int(args[0])
+            if index < len(self.list_indexes):
+                try:
+                    self.do_play('"{}" {}'.format(self.list_indexes[index],
+                                                  args[1]))
+                except IndexError: 
+                    self.do_play('"{}"'.format(self.list_indexes[index]))
                 return 0
         except (ValueError, AttributeError):
-            pass
+            args = None
         if self.parse_args(arg):
             try:
                 args = self.parse_args(arg)


### PR DESCRIPTION
Changes:
Issuing 'list' will display indexes besides names, issuing 'play 1' will
play the show at that index, makes it easier to play long named shows or anything 
that doesn't autocomplete well.

Features:
Now you can simply 'list' your currently watched shows and type 'play 5'
instead of typing by hand 'play "Fate/stay night: Unlimited Blade Works (TV)"'.
Specifying episode 1 for example: 'play 5 1'
Works with list made through filter/search (anything that produces a list with _make_list)

Caveats:
Adds additional column for indexes in the list, widening it somewhat.
Returns "show not found" error if trying to play by index before issuing list. 
Implementation might be a bit crude.
