### PR TITLE
Fixes #73 as reintroduced to 'do_play' by #76

### DIFF
--- a/wmal/ui/cli.py
+++ b/wmal/ui/cli.py
@@ -249,7 +249,7 @@ class wmal_cmd(cmd.Cmd):
                 except IndexError: 
                     self.do_play('"{}"'.format(self.list_indexes[index]))
                 return 0
-        except (ValueError, AttributeError):
+        except (ValueError, AttributeError, IndexError):
             args = None
         if self.parse_args(arg):
             try:


### PR DESCRIPTION
Sorry, not sure how I missed it. After #76 commands like "play !!!" caused wmal to crash again as described in #73.
