### PR TITLE
Fix a bug where a single result wouldn't be selected in search

### DIFF
--- a/trackma/ui/qtui.py
+++ b/trackma/ui/qtui.py
@@ -1031,6 +1031,7 @@ class AddDialog(QtGui.QDialog):
     def s_search(self):
         self.search_btn.setEnabled(False)
         self.select_btn.setEnabled(False)
+        self.table.clearSelection()
         self.table.setEnabled(False)
 
         self.worker_call('search', self.r_searched, self.search_txt.text())


### PR DESCRIPTION
This simply clears the current selection before a search occurs. If only a single result was present, it became impossible to select it as it seemed to be selected already. Sorry for the merge commits, forgot to rebase. ^^;

Edit: It works if you simply click another column. Kinda confusing, though. 