### PR TITLE
Anilist status fixes

### DIFF
--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -104,6 +104,7 @@ class libanilist(lib):
                 'publishing': 1,
                 'finished': 2,
                 'not yet published': 3,
+                'cancelled': 4,
             }
         else:
             self.total_str = "total_episodes"
@@ -113,6 +114,7 @@ class libanilist(lib):
                 'currently airing': 1,
                 'finished airing': 2,
                 'not yet aired': 3,
+                'cancelled': 4,
             }
 
         #handler=urllib2.HTTPHandler(debuglevel=1)

--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -340,7 +340,7 @@ class libanilist(lib):
                 ('Description',     item.get('description')),
                 ('Genres',          item.get('genres')),
                 ('Classification',  item.get('classification')),
-                ('Status',          item.get('airing_status')),
+                ('Status',          item.get(self.airing_str)),
                 ('Average score',   item.get('average_score')),
                 ('Japanese title',  item.get('title_japanese')),
                 ('English title',   item.get('title_english')),


### PR DESCRIPTION
This fixes two bugs at libanilist.

Parsing bug: in the parsing function, instead of using the string that change with the mediatype (self.airing_str), 'airing_status' is used. This prevents the manga statuses to be parsed.

Retrieve bug: anilist added some months ago the cancelled status, if you have in your list one item that has this status, trackma raises a KeyError. I set cancelled to 4, but 2 could do, cancelled is like finished.