### PR TITLE
Made the Qt play next button visible

### DIFF
--- a/trackma/ui/qtui.py
+++ b/trackma/ui/qtui.py
@@ -241,6 +241,7 @@ class Trackma(QtGui.QMainWindow):
         left_box.addRow(self.show_rem_btn)
         left_box.addRow(self.show_progress_btn)
         left_box.addRow(self.show_play_btn)
+        left_box.addRow(self.show_play_next_btn)
         left_box.addRow(show_score_label, self.show_score)
         left_box.addRow(self.show_score_btn)
         left_box.addRow(self.show_status)


### PR DESCRIPTION
In the Qt interface, the play next button existed, but it was never added to a layout. This adds it underneath the play button.
![qtnext](https://cloud.githubusercontent.com/assets/6378510/8981040/c9541d28-367a-11e5-84a1-d2bdddeb8284.png)
