### PR TITLE
libanilist: Fixed an exception when trying to delete

### DIFF
--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -267,8 +267,12 @@ class libanilist(lib):
         self.check_credentials()
         self.msg.info(self.name, "Deleting item %s..." % item['title'])
 
-        data = self._request("DELETE", "{}list/{}".format(self.mediatype, item['id']), auth=True)
-        return True
+        try:
+            data = self._request("DELETE", "{}list/{}".format(self.mediatype, item['id']), auth=True)
+        except ValueError:
+            # An empty document, without any JSON, is returned
+            # when the delete worked.
+            return True
 
     def search(self, criteria):
         self.check_credentials()


### PR DESCRIPTION
The anilist API returns an empty response when you delete an entry. At the _request function, the response is parsed and raise a ValueError. The entry is deleted at anilist, but trackma crashes.

I used a try/except just like in the search function. First, I did `if method == "DELETE"` in _request, but I think it's better this way because it only runs when the delete function is called.