### PR TITLE
[Anilist] Additional info fields; Start date on lists

### DIFF
--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -247,6 +247,7 @@ class libanilist(lib):
                     'total': self._c(item[self.mediatype][self.total_str]),
                     'image': item[self.mediatype]['image_url_lge'],
                     'image_thumb': item[self.mediatype]['image_url_med'],
+                    'url': str("http://anilist.co/%s/%d" % (self.mediatype, showid)),
                 })
 
                 showlist[showid] = show
@@ -301,6 +302,7 @@ class libanilist(lib):
                 'total': item[self.total_str],
                 'image': item['image_url_lge'],
                 'image_thumb': item['image_url_med'],
+                'url': str("http://anilist.co/%s/%d" % (self.mediatype, showid)),
             })
 
             showlist.append( show )
@@ -343,9 +345,9 @@ class libanilist(lib):
             'title': item['title_romaji'],
             'status': self.status_translate[item[self.airing_str]],
             'image': item['image_url_lge'],
+            'url': str("http://anilist.co/%s/%d" % (self.mediatype, showid)),
             'start_date': self._str2date(item.get('start_date')),
             'end_date': self._str2date(item.get('end_date')),
-            'url': "http://anilist.co/%s/%d" % (self.mediatype, showid),
             'extra': [
                 ('English',         item.get('title_english')),
                 ('Japanese',        item.get('title_japanese')),

--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -33,7 +33,7 @@ class libanilist(lib):
     msg = None
     logged_in = False
 
-    api_info = { 'name': 'Anilist', 'shortname': 'anilist', 'version': '1', 'merge': False }
+    api_info = { 'name': 'Anilist', 'shortname': 'anilist', 'version': '1.1', 'merge': True }
     mediatypes = dict()
     mediatypes['anime'] = {
         'has_progress': True,
@@ -336,6 +336,10 @@ class libanilist(lib):
 
         data = self._request(method, "{}list".format(self.mediatype), post=values, auth=True)
         return True
+
+    def merge(self, show, info):
+        show['start_date'] = info.get('start_date')
+        show['end_date'] = info.get('end_date')
 
     def _parse_info(self, item):
         info = utils.show()

--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -19,7 +19,7 @@ import trackma.utils as utils
 
 import json
 import urllib, urllib2, socket
-import time
+import time, datetime
 
 class libanilist(lib):
     """
@@ -337,22 +337,39 @@ class libanilist(lib):
 
     def _parse_info(self, item):
         info = utils.show()
+        showid = item['id']
         info.update({
-            'id': item['id'],
+            'id': showid,
             'title': item['title_romaji'],
             'status': self.status_translate[item[self.airing_str]],
             'image': item['image_url_lge'],
+            'start_date': self._str2date(item.get('start_date')),
+            'end_date': self._str2date(item.get('end_date')),
+            'url': "http://anilist.co/%s/%d" % (self.mediatype, showid),
             'extra': [
-                ('Description',     item.get('description')),
-                ('Genres',          item.get('genres')),
+                ('English',         item.get('title_english')),
+                ('Japanese',        item.get('title_japanese')),
                 ('Classification',  item.get('classification')),
-                ('Status',          item.get(self.airing_str)),
+                ('Genres',          item.get('genres')),
+                ('Synopsis',        item.get('description')),
+                ('Type',            item.get('type')),
                 ('Average score',   item.get('average_score')),
-                ('Japanese title',  item.get('title_japanese')),
-                ('English title',   item.get('title_english')),
+                ('Status',          item.get(self.airing_str)),
+                ('Start Date',      item.get('start_date')),
+                ('End Date',        item.get('end_date')),
             ]
         })
         return info
+
+    def _str2date(self, string):
+        if string is not None:
+            try:
+                return datetime.datetime.strptime(string[:10], "%Y-%m-%d")
+            except ValueError:
+                return None # Ignore date if it's invalid
+        else:
+            return None
+
 
     def _c(self, s):
         return 0 if s is None else s


### PR DESCRIPTION
Reordered the info and renamed some data to be more in line with libmal. Uses the merge method libvndb does to get start date on the list views (yay, estimated eps) so first run will take a while on accounts with a fair bit of anime. Old anime.info files will prevent loading the new fields, considering adding a button in Qt options to purge old db but I'm open to other suggestions in dealing with stale dbs.