### PR TITLE
[Anilist][Utils][Qt] Anilist improvements

### DIFF
--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -32,7 +32,6 @@ class libanilist(lib):
     name = 'libanilist'
     msg = None
     logged_in = False
-    max_airing_api_calls = 0 # If more than this many shows need to get airing data, request full airing list (~150kB) instead of each item individually
 
     api_info = { 'name': 'Anilist', 'shortname': 'anilist', 'version': '1.1', 'merge': False }
     mediatypes = dict()
@@ -258,7 +257,7 @@ class libanilist(lib):
                 showlist[showid] = show
 
         if self.mediatype == 'anime': # Airing data unavailable for manga
-            if len(airinglist) > self.max_airing_api_calls: # Request all airing anime in one go (~150kB)
+            if len(airinglist) > 0:
                 browseparam = {'access_token': self._get_userconfig('access_token'),
                          'status': 'Currently Airing',
                          'airing_data': 'true',
@@ -271,17 +270,6 @@ class libanilist(lib):
                             showlist[id].update({
                                 'next_ep_number': item['airing']['next_episode'],
                                 'next_ep_time': item['airing']['time'],
-                            })
-            else: # Request individually
-                for id in airinglist:
-                    data = self._request("GET", "anime/{0}/airing".format(id), get=param)
-                    # This API actually returns all of the available episode airing data, seemingly unordered.
-                    # As such, it is even more overkill than using the browse API.
-                    if data:
-                        for key, value in data.items(): # This does not work. Do not use without modification.
-                            showlist[id].update({
-                                'next_ep_number': int(key),
-                                'next_ep_time': value,
                             })
         return showlist
 

--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -247,6 +247,7 @@ class libanilist(lib):
                     'total': self._c(item[self.mediatype][self.total_str]),
                     'image': item[self.mediatype]['image_url_lge'],
                     'image_thumb': item[self.mediatype]['image_url_med'],
+                    'url': str("http://anilist.co/%s/%d" % (self.mediatype, showid)),
                 })
 
                 showlist[showid] = show
@@ -301,6 +302,7 @@ class libanilist(lib):
                 'total': item[self.total_str],
                 'image': item['image_url_lge'],
                 'image_thumb': item['image_url_med'],
+                'url': str("http://anilist.co/%s/%d" % (self.mediatype, showid)),
             })
 
             showlist.append( show )
@@ -343,9 +345,9 @@ class libanilist(lib):
             'title': item['title_romaji'],
             'status': self.status_translate[item[self.airing_str]],
             'image': item['image_url_lge'],
+            'url': str("http://anilist.co/%s/%d" % (self.mediatype, showid)),
             'start_date': self._str2date(item.get('start_date')),
             'end_date': self._str2date(item.get('end_date')),
-            'url': "http://anilist.co/%s/%d" % (self.mediatype, showid),
             'extra': [
                 ('English',         item.get('title_english')),
                 ('Japanese',        item.get('title_japanese')),

--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -32,8 +32,9 @@ class libanilist(lib):
     name = 'libanilist'
     msg = None
     logged_in = False
+    max_airing_api_calls = 0 # If more than this many shows need to get airing data, request full airing list (~150kB) instead of each item individually
 
-    api_info = { 'name': 'Anilist', 'shortname': 'anilist', 'version': '1', 'merge': False }
+    api_info = { 'name': 'Anilist', 'shortname': 'anilist', 'version': '1.1', 'merge': False }
     mediatypes = dict()
     mediatypes['anime'] = {
         'has_progress': True,
@@ -220,6 +221,7 @@ class libanilist(lib):
         data = self._request("GET", "user/{0}/{1}list".format(self.userid, self.mediatype), get=param)
 
         showlist = {}
+        airinglist = []
 
         #with open('list', 'w') as f:
         #    json.dump(data, f, indent=2)
@@ -250,8 +252,37 @@ class libanilist(lib):
                     'url': str("http://anilist.co/%s/%d" % (self.mediatype, showid)),
                 })
 
+                if show['status'] == 1:
+                    airinglist.append(showid)
+
                 showlist[showid] = show
 
+        if self.mediatype == 'anime': # Airing data unavailable for manga
+            if len(airinglist) > self.max_airing_api_calls: # Request all airing anime in one go (~150kB)
+                browseparam = {'access_token': self._get_userconfig('access_token'),
+                         'status': 'Currently Airing',
+                         'airing_data': 'true',
+                         'full_page': 'true'}
+                data = self._request("GET", "browse/anime", get=browseparam)
+                for item in data:
+                    id = item['id']
+                    if id in showlist and 'airing' in item:
+                        if item['airing']:
+                            showlist[id].update({
+                                'next_ep_number': item['airing']['next_episode'],
+                                'next_ep_time': item['airing']['time'],
+                            })
+            else: # Request individually
+                for id in airinglist:
+                    data = self._request("GET", "anime/{0}/airing".format(id), get=param)
+                    # This API actually returns all of the available episode airing data, seemingly unordered.
+                    # As such, it is even more overkill than using the browse API.
+                    if data:
+                        for key, value in data.items(): # This does not work. Do not use without modification.
+                            showlist[id].update({
+                                'next_ep_number': int(key),
+                                'next_ep_time': value,
+                            })
         return showlist
 
     def add_show(self, item):

--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -19,7 +19,7 @@ import trackma.utils as utils
 
 import json
 import urllib, urllib2, socket
-import time
+import time, datetime
 
 class libanilist(lib):
     """
@@ -337,22 +337,39 @@ class libanilist(lib):
 
     def _parse_info(self, item):
         info = utils.show()
+        showid = item['id']
         info.update({
-            'id': item['id'],
+            'id': showid,
             'title': item['title_romaji'],
             'status': self.status_translate[item[self.airing_str]],
             'image': item['image_url_lge'],
+            'start_date': self._str2date(item.get('start_date')),
+            'end_date': self._str2date(item.get('end_date')),
+            'url': "http://anilist.co/%s/%d" % (self.mediatype, showid),
             'extra': [
-                ('Description',     item.get('description')),
-                ('Genres',          item.get('genres')),
+                ('English',         item.get('title_english')),
+                ('Japanese',        item.get('title_japanese')),
                 ('Classification',  item.get('classification')),
-                ('Status',          item.get(self.airing_str)),
+                ('Genres',          item.get('genres')),
+                ('Synopsis',        item.get('description')),
+                ('Type',            item.get('type')),
                 ('Average score',   item.get('average_score')),
-                ('Japanese title',  item.get('title_japanese')),
-                ('English title',   item.get('title_english')),
+                ('Status',          item.get(self.airing_str)),
+                ('Start Date',      item.get('start_date')),
+                ('End Date',        item.get('end_date')),
             ]
         })
         return info
+
+    def _str2date(self, string):
+        if string is not None:
+            try:
+                return datetime.datetime.strptime(string[:10], "%Y-%m-%d")
+            except ValueError:
+                return None # Ignore date if it's invalid
+        else:
+            return None
+
 
     def _c(self, s):
         return 0 if s is None else s

--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -43,6 +43,7 @@ class libanilist(lib):
         'can_status': True,
         'can_update': True,
         'can_play': True,
+        'date_next_ep': True,
         'status_start': 'watching',
         'status_finish': 'completed',
         'statuses':  ['watching', 'completed', 'on-hold', 'dropped', 'plan to watch'],

--- a/trackma/ui/qtui.py
+++ b/trackma/ui/qtui.py
@@ -46,6 +46,15 @@ except ImportError:
         print "Warning: PIL or Pillow isn't available. Preview images will be disabled."
         imaging_available = False
 
+try:
+    import dateutil.parser
+    import dateutil.tz
+    import datetime
+    dateutil_available = True
+except ImportError:
+    print "Warning: DateUtil is unavailable. Next episode countdown will be disabled."
+    dateutil_available = False
+
 class Trackma(QtGui.QMainWindow):
     """
     Main GUI class
@@ -456,6 +465,8 @@ class Trackma(QtGui.QMainWindow):
 
         widget = self.show_lists[status]
         columns = ['ID', 'Title', 'Progress', 'Score', 'Percent', 'Date']
+        if 'date_next_ep' in self.mediainfo and self.mediainfo['date_next_ep']:
+            columns[5] = 'Next Episode'
         widget.clear()
         widget.setSortingEnabled(False)
         widget.setRowCount(len(showlist))
@@ -526,6 +537,13 @@ class Trackma(QtGui.QMainWindow):
         widget.setItem(row, 4, ShowItemNum( percent, str(percent), color ))
         widget.setCellWidget(row, 4, percent_widget )
         widget.setItem(row, 5, ShowItemDate( show['start_date'], color ))
+        if 'date_next_ep' in self.mediainfo \
+        and self.mediainfo['date_next_ep'] \
+        and 'next_ep_time' in show \
+        and dateutil_available:
+            next_ep_dt = dateutil.parser.parse(show['next_ep_time'])
+            delta = next_ep_dt - datetime.datetime.now(dateutil.tz.tzutc())
+            widget.setItem(row, 5, ShowItem( "%i days, %02d hrs." % (delta.days, delta.seconds/3600), color ))
 
     def _get_color(self, is_playing, show, eps):
         if is_playing:

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -144,21 +144,24 @@ def get_root():
 
 def estimate_aired_episodes(show):
     # Estimate how many episodes have passed since airing
-    # Let's just assume 1 episode = 1 week
-    if not show['start_date']:
-        return
 
-    if show['status'] == 1:
-        days = (datetime.datetime.now() - show['start_date']).days
-        if days <= 0:
-            return 0
-
-        eps = days / 7 + 1
-        if eps > show['total']:
-            return show['total']
-        return eps
-    elif show['status'] == 2:
+    if show['status'] == 2:     # If it's 'finished airing', then all episodes have aired
         return show['total']
+    elif show['status'] == 3:   # If it's 'not yet aired', then no episodes have aired
+        return 0
+    elif show['status'] == 1:   # It's airing, so we make an estimate based on available information
+        if 'next_ep_number' in show: # Do we have the upcoming episode number?
+            return show['next_ep_number']-1
+        elif show['start_date']: # Do we know when it started? Let's just assume 1 episode = 1 week
+            days = (datetime.datetime.now() - show['start_date']).days
+            if days <= 0:
+                return 0
+
+            eps = days / 7 + 1
+            if eps > show['total']:
+                return show['total']
+            return eps
+    return
 
 def guess_show(show_title, tracker_list):
     # Use difflib to see if the show title is similar to


### PR DESCRIPTION
Reordered the info and renamed some data to be more in line with libmal, fixed URL generation. Uses airing data from the anilist browse API (1 request per sync, ~150kB json) to determine number of episodes aired for airing shows. Replaces defunct (start-)date column for anilist anime with a simple days,hours countdown to the next episode (only updates on table regeneration, I may revisit this later).

Anilist API version bump from 1 to 1.1