### PR TITLE
[Gtk] Minor additional options

### DIFF
--- a/trackma/ui/gtkui.py
+++ b/trackma/ui/gtkui.py
@@ -452,6 +452,8 @@ class Trackma_gtk(object):
             self.engine.api_info['name'],
             self.engine.api_info['mediatype']))
         self.api_icon.set_from_file(api_iconfile)
+        if self.config['tray_api_icon']:
+            self.statusicon.set_from_file(api_iconfile)
         self.api_user.set_text("%s (%s)" % (
             self.engine.get_userconfig('username'),
             self.engine.api_info['mediatype']))

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -308,6 +308,12 @@ gtk_defaults = {
     'show_tray': True,
     'close_to_tray': True,
     'start_in_tray': False,
+    'tray_api_icon': False,
+    'remember_geometry': False,
+    'last_width': 740,
+    'last_height': 480,
+    'episodebar_style': 1,
+    'episodebar_text': False,
     'colors': {
         'is_airing': '#0099CC',
         'is_playing': '#6C2DC7',

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -313,7 +313,6 @@ gtk_defaults = {
     'last_width': 740,
     'last_height': 480,
     'episodebar_style': 1,
-    'episodebar_text': False,
     'colors': {
         'is_airing': '#0099CC',
         'is_playing': '#6C2DC7',


### PR DESCRIPTION
Added options for remembering window geometry (#140), using standard progress bar widgets (#153) and using API icons in the tray (port of #159). Fixed percent sort.

I'm giving up on overlaying the episode subbar onto the standard widget in Gtk, but I'll probably get around to adding a theme-aware colour picker within the next week.