### PR TITLE
[Qt] Columns per api

### DIFF
--- a/trackma/ui/gtkui.py
+++ b/trackma/ui/gtkui.py
@@ -437,9 +437,6 @@ class Trackma_gtk(object):
 
         self.show_ep_num.hide()
 
-        if not self.config['visible_columns']:
-            self.config['visible_columns'] = ['Title', 'Progress', 'Score', 'Percent']
-
         self.start_engine()
 
     def _clear_gui(self):

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -316,7 +316,7 @@ gtk_defaults = {
     'remember_geometry': False,
     'last_width': 740,
     'last_height': 480,
-    'visible_columns': [],
+    'visible_columns': ['Title', 'Progress', 'Score', 'Percent'],
     'episodebar_style': 1,
     'colors': {
         'is_airing': '#0099CC',

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -344,6 +344,7 @@ qt_defaults = {
     'last_width': 740,
     'last_height': 480,
     'visible_columns': ['Title', 'Progress', 'Score', 'Percent'],
+    'columns_per_api': False,
     'episodebar_style': 1,
     'episodebar_text': False,
     'colors': {
@@ -358,4 +359,8 @@ qt_defaults = {
         'progress_sub_fg': '#5187B1',
         'progress_complete': '#00D200',
     },
+}
+
+qt_per_api_defaults = {
+    'visible_columns': ['Title', 'Progress', 'Score', 'Percent'],
 }


### PR DESCRIPTION
Adds an option to have separate visible columns settings per API. These are stored in ui-qt.{api}.json, which might be used for additional future features that may warrant having different settings between APIs.
![sepcolumns](https://cloud.githubusercontent.com/assets/5397662/11456927/b98aa5ea-96e9-11e5-9c79-09114a76ea79.png)
