### PR TITLE
[Engine][libanilist] Added shows default to PTW, anilist bugfix

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -342,8 +342,12 @@ class Engine:
         if status:
             if status not in self.mediainfo['statuses']:
                 raise utils.EngineError('Invalid status.')
+            else:
+                show['my_status'] = status
+        else:
+            # Default add to 'plan to read/watch'
+            show['my_status'] = self.mediainfo['statuses'][-1]
 
-            show['my_status'] = status
 
         # Add in data handler
         self.data_handler.queue_add(show)

--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -237,7 +237,7 @@ class libanilist(lib):
 
                 show = utils.show()
                 showid = item[self.mediatype]['id']
-                show.update({
+                showdata = {
                     'id': showid,
                     'title': item[self.mediatype]['title_romaji'],
                     'aliases': [item[self.mediatype]['title_english']],
@@ -250,7 +250,8 @@ class libanilist(lib):
                     'image': item[self.mediatype]['image_url_lge'],
                     'image_thumb': item[self.mediatype]['image_url_med'],
                     'url': str("http://anilist.co/%s/%d" % (self.mediatype, showid)),
-                })
+                }
+                show.update({k:v for k,v in showdata.items() if v})
 
                 if show['status'] == 1:
                     airinglist.append(showid)
@@ -312,7 +313,7 @@ class libanilist(lib):
         for item in data:
             show = utils.show()
             showid = item['id']
-            show.update({
+            showdata = {
                 'id': showid,
                 'title': item['title_romaji'],
                 'aliases': [item['title_english']],
@@ -323,7 +324,8 @@ class libanilist(lib):
                 'image': item['image_url_lge'],
                 'image_thumb': item['image_url_med'],
                 'url': str("http://anilist.co/%s/%d" % (self.mediatype, showid)),
-            })
+            }
+            show.update({k:v for k,v in showdata.items() if v})
 
             showlist.append( show )
 


### PR DESCRIPTION
Having shows add straight to PTW is convenient as often shows are added to userlists ahead of time, and they move to Watching when the tracker picks them up.
Anilist omits placeholder data on the total field for some shows, messing up the UI when those shows are added. 1263516 should not only fix this issue but any other omissions.