### PR TITLE
Modify accounts.dict to initialize with mode 0600

### DIFF
--- a/trackma/accounts.py
+++ b/trackma/accounts.py
@@ -24,7 +24,10 @@ class AccountManager(object):
                 self.accounts = cPickle.load(f)
 
     def _save(self):
+        is_new = not utils.file_exists(self.filename)
         with open(self.filename, 'wb') as f:
+            if is_new:
+                utils.change_permissions(self.filename, 0o600)
             cPickle.dump(self.accounts, f)
 
     def add_account(self, username, password, api):

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -143,6 +143,9 @@ def get_root_filename(filename):
 def get_root():
     return os.path.expanduser(os.path.join('~', '.trackma'))
 
+def change_permissions(filename, mode):
+    os.chmod(filename, mode)
+
 def estimate_aired_episodes(show):
     # Estimate how many episodes have passed since airing
 


### PR DESCRIPTION
Since accounts.dict stores usernames and passwords, most (Unix) applications typically create such files to be read/writable only by owner. This patch does just that by allowing accounts.AccountManager.save to change the file permissions on initialization. Since this is only done once, the user can manually change the permissions on accounts.dict to allow group or all access, and future saves will respect those permissions.

It's a minor security change, but I just feel fidgety when I see my passwords in a globally readable file. :)