### PR TITLE
[Qt] fix simple progress bar style

### DIFF
--- a/trackma/ui/qtui.py
+++ b/trackma/ui/qtui.py
@@ -36,7 +36,7 @@ if try_pyqt5:
                                     QDialog, QColorDialog, QDialogButtonBox,
                                     QFileDialog, QInputDialog, QMessageBox,
                                     QAction, QActionGroup, QLabel, QMenu, QStyle,
-                                    QSystemTrayIcon)
+                                    QSystemTrayIcon, QStyleOptionProgressBar)
         pyqt_version = 5
     except ImportError:
         print ("Couldn't import Qt5 dependencies. Make sure you "
@@ -58,6 +58,7 @@ if pyqt_version is 0:
                                 QDialog, QColorDialog, QDialogButtonBox, QFileDialog, QInputDialog, QMessageBox,
                                 QAction, QActionGroup, QLabel, QMenu, QStyle,
                                 QSystemTrayIcon, QIcon, QPalette)
+        from PyQt4.QtGui import QStyleOptionProgressBarV2 as QStyleOptionProgressBar
         pyqt_version = 4
     except ImportError:
         print ("Couldn't import Qt dependencies. Make sure you "
@@ -2521,7 +2522,7 @@ class EpisodeBar(QProgressBar):
 
         if self._bar_style is self.BarStyleBasic:
             painter = QtGui.QPainter(self)
-            prog_options = QtGui.QStyleOptionProgressBarV2()
+            prog_options = QStyleOptionProgressBar()
             prog_options.maximum = self.maximum()
             prog_options.progress = self.value()
             prog_options.rect = rect
@@ -2552,7 +2553,7 @@ class EpisodeBar(QProgressBar):
             painter.setCompositionMode(QtGui.QPainter.CompositionMode_Source)
             painter.fillRect(rect, QtCore.Qt.transparent)
             painter.setCompositionMode(QtGui.QPainter.CompositionMode_SourceOver)
-            prog_options = QtGui.QStyleOptionProgressBarV2()
+            prog_options = QStyleOptionProgressBar()
             prog_options.maximum = self.maximum()
             prog_options.progress = self.value()
             prog_options.rect = rect


### PR DESCRIPTION
During my work on #212, I discovered that Qt UI has broken simple progress bar style:

```console
rr-@tornado:~/src/ext/trackma$ trackma-qt
Warning: DateUtil is unavailable. Next episode countdown will be disabled.
Data: Locking database...
Data: Reading metadata...
Data: Reading queue...
Data: No items in queue.
libmal: Logging in...
Data: Saving userconfig...
libmal: Downloading list...
libmal: Parsing anime list...
Data: Saving cache...
Data: Saving metadata...
Tracker: Initializing...
Tracker: Enabling tracker...
Tracker: inotifyx not available; using polling (slow).
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/Trackma-0.4-py2.7.egg/trackma/ui/qtui.py", line 2555, in paintEvent
    prog_options = QtGui.QStyleOptionProgressBarV2()
AttributeError: 'module' object has no attribute 'QStyleOptionProgressBarV2'
zsh: abort (core dumped)  trackma-qt
```