### PR TITLE
Py3 CLI

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -289,7 +289,7 @@ class Engine:
         showdict = self.data_handler.get()
         # Do title lookup, slower
         for k, show in showdict.items():
-            if show['title'].encode('utf-8') == pattern:
+            if show['title'] == pattern:
                 return show
         raise utils.EngineError("Show not found.")
 

--- a/trackma/lib/libmelative.py
+++ b/trackma/lib/libmelative.py
@@ -155,7 +155,7 @@ class libmelative(lib):
 
             show = utils.show()
             show['id'] = itemid
-            show['title'] = entity['aliases'][0].encode('utf-8')
+            show['title'] = entity['aliases'][0]
             show['my_status'] = _status
             show['my_score'] = int(record['rating'] or 0)
             show['my_progress'] =_progress

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -113,7 +113,7 @@ class Trackma_cmd(cmd.Cmd):
             return self.engine.get_show_info_title(title)
 
     def _ask_update(self, show, episode):
-        do_update = input("Should I update %s to episode %d? [y/N] " % (show['title'].encode('utf-8'), episode))
+        do_update = input("Should I update %s to episode %d? [y/N] " % (show['title'], episode))
         if do_update.lower() == 'y':
             self.engine.set_episode(show['id'], episode)
 
@@ -361,7 +361,7 @@ class Trackma_cmd(cmd.Cmd):
         try:
             show = self._get_show(args[0])
 
-            do_delete = input("Delete %s? [y/N] " % show['title'].encode('utf-8'))
+            do_delete = input("Delete %s? [y/N] " % show['title'])
             if do_delete.lower() == 'y':
                 self.engine.delete_show(show)
         except utils.TrackmaError as e:
@@ -510,7 +510,7 @@ class Trackma_cmd(cmd.Cmd):
         if len(queue):
             print("Queue:")
             for show in queue:
-                print("- %s" % show['title'].encode('utf-8'))
+                print("- %s" % show['title'])
         else:
             print("Queue is empty.")
 
@@ -703,7 +703,7 @@ class Trackma_cmd(cmd.Cmd):
                 episodes_str = "-"
 
             # Truncate title if needed
-            title_str = show['title'].encode('utf-8')
+            title_str = show['title']
             title_str = title_str[:max_title_length] if len(title_str) > max_title_length else title_str
 
             # Color title according to status

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -556,7 +556,7 @@ class Trackma_cmd(cmd.Cmd):
             return self.engine.regex_list_titles(text)
 
     def complete_filter(self, text, line, begidx, endidx):
-        return (v.lower().replace(' ', '') for v in self.engine.mediainfo['statuses_dict'].values())
+        return [v.lower().replace(' ', '') for v in self.engine.mediainfo['statuses_dict'].values()]
 
     def parse_args(self, arg):
         if arg:


### PR DESCRIPTION
The python3 port broke the CLI UI because some strings are encoded to utf8. In python2, that changed str to unicode to show utf8 characters, but in python3 it changes str to bytes; and str is the type wanted in this case. The other UIs worked with almost all the strings being bytes, but the cli breaks when trying to concatenate str with bytes implicitly.

Also, I changed the complete\_filter method because the Cmd complete\_\* methods should return a list.

I checked every cli method and I think all worked as intended. The cache files should be deleted before trying it. **I didn't check if the melative change is needed** because I don't have an account, please someone check it out before merging.