### PR TITLE
[Qt] Column cleanup

### DIFF
--- a/trackma/ui/qtui.py
+++ b/trackma/ui/qtui.py
@@ -493,6 +493,10 @@ class Trackma(QMainWindow):
         self.api_config = utils.parse_config(self.api_configfile, utils.qt_per_api_defaults)
         if self.config['columns_per_api']:
             self.config['visible_columns'] = self.api_config['visible_columns']
+        self.menu_columns_group.setEnabled(False)
+        for action in self.menu_columns_group.actions():
+            action.setChecked(action.text() in self.config['visible_columns'])
+        self.menu_columns_group.setEnabled(True)
 
         self.show()
         self._busy(False)

--- a/trackma/ui/qtui.py
+++ b/trackma/ui/qtui.py
@@ -1248,6 +1248,7 @@ class Trackma(QMainWindow):
     def s_toggle_column(self, w):
         (column_name, visible) = (w.text(), w.isChecked())
         index = self.available_columns.index(column_name)
+        MIN_WIDTH = 30  # Width to restore columns to if too small to see
 
         if visible:
             if column_name not in self.config['visible_columns']:
@@ -1263,6 +1264,8 @@ class Trackma(QMainWindow):
 
         for showlist in self.show_lists.values():
             showlist.setColumnHidden(index, not visible)
+            if visible and showlist.columnWidth(index) < MIN_WIDTH:
+                showlist.setColumnWidth(index, MIN_WIDTH)
 
     ### Worker slots
     def ws_changed_show(self, show, is_playing=False, episode=None, altname=None):


### PR DESCRIPTION
- Fixes the show/hide columns context menu not changing when switching accounts
- Makes columns show (unhide) with a minimum width to prevent confusion arising from zero-width columns
