### PR TITLE
Fix KeyError due to completed manga status

### DIFF
--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -106,7 +106,7 @@ class libanilist(lib):
             self.airing_str = "publishing_status"
             self.status_translate = {
                 'publishing': utils.STATUS_AIRING,
-                'finished': utils.STATUS_FINISHED,
+                'finished publishing': utils.STATUS_FINISHED,
                 'not yet published': utils.STATUS_NOTYET,
                 'cancelled': utils.STATUS_CANCELLED,
             }


### PR DESCRIPTION
Changes the status translation of completed manga in the Anilist library to reflect changes (?) to the API.

Fixes trackma crashing due to KeyError when using Anilist.