### PR TITLE
setup.py: fix requirements issue with `gi` package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ NAME = "Trackma"
 REQUIREMENTS = []
 EXTRA_REQUIREMENTS = {
     'curses': ['urwid'],
-    'GTK': ['gi', 'Pillow'],
+    'GTK': ['pygobject', 'Pillow'],
     'Qt': ['Pillow'],
 }
 


### PR DESCRIPTION
refer to  `pygobject` in the GTK requirements, so that setuptools can find it.

Fixes #228; tested on Arch Linux, but will probably work the same on other distributions.