### PR TITLE
[libanilist] Proper error on no search results

### DIFF
--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -314,6 +314,8 @@ class libanilist(lib):
         showlist = []
 
         for item in data:
+            if type(item) is not dict:
+                return []
             show = utils.show()
             showid = item['id']
             showdata = {


### PR DESCRIPTION
The Anilist API now seems to return ["error"] when there are no search results, which causes a problem when the parser then tries to take a string literal index of the string. Added a check for non-dict items to avoid this.