### PR TITLE
CLI Altnames

### DIFF
--- a/trackma/data.py
+++ b/trackma/data.py
@@ -435,7 +435,8 @@ class Data():
         self.meta['altnames'][showid] = altname
 
     def altname_clear(self, showid):
-        del self.meta['altnames'][showid]
+        if showid in self.meta['altnames']:
+            del self.meta['altnames'][showid]
 
     def altnames_get(self):
         return self.meta['altnames']

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -672,6 +672,7 @@ class Trackma_cmd(cmd.Cmd):
         col_title_length = 5
         col_episodes_length = 9
         col_score_length = 6
+        altnames = self.engine.altnames()
 
         # Calculate maximum width for the title column
         # based on the width of the terminal
@@ -691,7 +692,7 @@ class Trackma_cmd(cmd.Cmd):
         # Print header
         print("| {0:{1}} {2:{3}} {4:{5}} {6:{7}} |".format(
                 'Index',    col_index_length,
-                'Title',    col_title_length,
+                'Title',    max_title_length,
                 'Progress', col_episodes_length,
                 'Score',    col_score_length))
 
@@ -702,8 +703,10 @@ class Trackma_cmd(cmd.Cmd):
             else:
                 episodes_str = "-"
 
-            # Truncate title if needed
+            #Get title (and alt. title) and if need be, truncate it
             title_str = show['title']
+            if altnames.get(show['id']):
+                title_str += "[{}]".format(altnames.get(show['id']))
             title_str = title_str[:max_title_length] if len(title_str) > max_title_length else title_str
 
             # Color title according to status
@@ -715,7 +718,7 @@ class Trackma_cmd(cmd.Cmd):
             print("| {0:^{1}} {2}{3} {4:{5}} {6:^{7}} |".format(
                 index, col_index_length,
                 colored_title,
-                '.' * (col_title_length-len(show['title'])),
+                '.' * (max_title_length-len(title_str)),
                 episodes_str, col_episodes_length,
                 show['my_score'], col_score_length))
 

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -63,6 +63,7 @@ class Trackma_cmd(cmd.Cmd):
     stdout = sys.stdout
     sortedlist = []
     needed_args = {
+        'altname':      (1, 2),
         'filter':       (0, 1),
         'sort':         1,
         'mediatype':    (0, 1),
@@ -466,6 +467,27 @@ class Trackma_cmd(cmd.Cmd):
         try:
             show = self._get_show(_showtitle)
             self.engine.set_status(show['id'], _filter_num)
+        except utils.TrackmaError as e:
+            self.display_error(e)
+
+    def do_altname(self, args):
+        """
+        Changes the alternative name of a show.
+        Use the command 'altname' without arguments to clear the alternative
+        name.
+
+        :param show Show index or name
+        :param alt  The alternative name. Use `altname` without alt to clear it
+        :usage altname <show index or name> <alternative name>
+        """
+        try:
+            altnames = self.engine.altnames()
+            show = self._get_show(args[0])
+            altname = args[1] if len(args) > 1 else ''
+            self.engine.altname(show['id'],altname)
+        except IndexError:
+            print("Missing arguments")
+            return
         except utils.TrackmaError as e:
             self.display_error(e)
 


### PR DESCRIPTION
Implements #241. 

I also extended the title length and dot padding to the maximum length instead of `col_title_length` because when encountering titles that used up the full length (something that might become more common when also showing the alternative names) their rows would be misaligned like so:
![](http://i.imgur.com/YJNNlys.png)

This might just be on my side though, but either way, I think giving the titles the most room looks better anyway, and `col_title_length` is taken into account by the maximum length anyway.

Lastly, fixed a small KeyError on trying to clear an alternative title where there was none.