### PR TITLE
[Tracker][Engine][Qt] Prompt to add unrecognised shows.

### DIFF
--- a/trackma/tracker.py
+++ b/trackma/tracker.py
@@ -367,7 +367,7 @@ class Tracker():
                     if countdown > 0:
                         if state == STATE_PLAYING:
                             self.msg.info(self.name, 'Will update %s %d in %d seconds' % (show['title'], episode, countdown))
-                        else:
+                        elif state == STATE_NOT_FOUND:
                             self.msg.info(self.name, 'Will add %s %d in %d seconds' % (show, episode, countdown))
                     else:
                         # Time has passed, let's update
@@ -392,7 +392,7 @@ class Tracker():
                 if self.last_close_queue:
                     if self.last_state == STATE_PLAYING:
                         self._emit_signal('update', last_show['id'], last_show_ep)
-                    else:  # Assume state is STATE_NOT_FOUND
+                    elif self.last_state == STATE_NOT_FOUND:
                         self._emit_signal('unrecognised', last_show, last_show_ep)
                 elif not self.last_updated:
                     self.msg.info(self.name, 'Player was closed before update.')

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -265,6 +265,7 @@ config_defaults = {
     'tracker_update_wait_s': 120,
     'tracker_update_close': False,
     'tracker_update_prompt': False,
+    'tracker_not_found_prompt': False,
     'tracker_interval': 10,
     'tracker_process': 'mplayer|mplayer2|mpv',
     'autoretrieve': 'days',


### PR DESCRIPTION
Adds an option to prompt to add new shows to your list as/after you watch them. The prompt is the same as the regular search/add from remote dialog, however it starts with the show title filled in (not searched without user input to prevent privacy leaks) and closes after a show is successfully added, then updates the episode counter to match the one that was detected.

Known issue: Changing tracker options requires a restart to take effect. Would it be overkill to add a tracker restart to settings changes that involve the tracker?