### PR TITLE
[tracker] Remove another assumption

### DIFF
--- a/trackma/tracker.py
+++ b/trackma/tracker.py
@@ -380,7 +380,7 @@ class Tracker():
                             # Update now
                             if state == STATE_PLAYING:
                                 self._emit_signal('update', show['id'], episode)
-                            else:  # Assume state is STATE_NOT_FOUND
+                            elif state == STATE_NOT_FOUND:
                                 self._emit_signal('unrecognised', show, episode)
         elif self.last_state != state:
             # React depending on state


### PR DESCRIPTION
Adds another safety check similar to 1d0e527 but for wait_close=False, which prevents the tracker from crashing when there is a previous show tuple but the previous state is not STATE_PLAYING. Should fix #255.