### PR TITLE
[Qt] Split setGeometry into resize and move. (fixes #246)

### DIFF
--- a/trackma/ui/qtui.py
+++ b/trackma/ui/qtui.py
@@ -374,8 +374,8 @@ class Trackma(QMainWindow):
 
         #self.setMinimumSize(740, 480)
         if self.config['remember_geometry']:
-            self.setGeometry(self.config['last_x'], self.config['last_y'],
-                             self.config['last_width'], self.config['last_height'])
+            self.resize(self.config['last_width'], self.config['last_height'])
+            self.move(self.config['last_x'], self.config['last_y'])
 
         self.show_image = QLabel('Trackma-qt')
         self.show_image.setFixedHeight(149)


### PR DESCRIPTION
Workaround taken from the bottom of https://www.tbi.univie.ac.at/~pmg/tutorials/QT/html/geometry.html
I'm disgusted by the need for it, but it seems to fix the problem on my window manager setup.

EDIT: If someone on Windows could test this it would be much appreciated!