### PR TITLE
Scan library for multiple statuses

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -181,9 +181,9 @@ class Engine:
 
     def _get_tracker_list(self, filter_num=None):
         tracker_list = []
-        if type(filter_num) == None:
+        if isinstance(fliter_num, None):
             source_list = self.get_list()
-        elif type(filter_num) == list:
+        elif isinstance(filter_num, list):
             source_list = []
             for status in filter_num:
                 if status is not self.mediainfo['status_finish']:

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -181,10 +181,17 @@ class Engine:
 
     def _get_tracker_list(self, filter_num=None):
         tracker_list = []
-        if filter_num:
-            source_list = self.filter_list(filter_num)
-        else:
+        if type(filter_num) == None:
             source_list = self.get_list()
+        elif type(filter_num) == list:
+            source_list = []
+            for status in filter_num:
+                if status is not self.mediainfo['status_finish']:
+                    self.msg.debug(self.name, "scanning for \
+                            {}".format(self.mediainfo['statuses_dict'][status]))
+                    source_list = source_list + self.filter_list(status)
+        else:
+            source_list = self.filter_list(filter_num)
 
         for show in source_list:
             tracker_list.append({'id': show['id'],
@@ -729,11 +736,15 @@ class Engine:
         library_cache = self.data_handler.library_cache_get()
 
         if not my_status:
-            my_status = self.mediainfo['status_start']
+            if self.config['scan_whole_list']:
+                my_status = self.mediainfo['statuses']
+            else:
+                my_status = self.mediainfo['status_start']
 
         self.msg.info(self.name, "Scanning local library...")
         self.msg.debug(self.name, "Directory: %s" % self.config['searchdir'])
         tracker_list = self._get_tracker_list(my_status)
+
 
         # Do a full listing of the media directory
         for fullpath, filename in utils.regex_find_videos('mkv|mp4|avi', self.config['searchdir']):

--- a/trackma/ui/gtkui.py
+++ b/trackma/ui/gtkui.py
@@ -773,8 +773,6 @@ class Trackma_gtk():
         self.allow_buttons(True)
 
     def task_scanlibrary(self):
-        self.allow_buttons(False)
-
         try:
             result = self.engine.scan_library(rescan=True)
         except utils.TrackmaError as e:

--- a/trackma/ui/gtkui.py
+++ b/trackma/ui/gtkui.py
@@ -1857,6 +1857,8 @@ class Settings(Gtk.Window):
         self.txt_searchdir.set_max_length(4096)
         self.browse_button = Gtk.Button('Browse...')
         self.browse_button.connect("clicked", self.__do_browse, 'Select search directory', self.txt_searchdir, True)
+        self.chk_library_autoscan = Gtk.CheckButton('Rescan library at startup')
+        self.chk_scan_whole_list  = Gtk.CheckButton('Scan through whole list')
         self.chk_tracker_enabled = Gtk.CheckButton()
         self.txt_plex_host = Gtk.Entry()
         self.txt_plex_host.set_max_length(4096)
@@ -1892,10 +1894,15 @@ class Settings(Gtk.Window):
         header1.set_use_markup(True)
         header1.set_xalign(0)
 
+        line0 = Gtk.HBox(False, 5)
+        line0.pack_start(lbl_searchdir, False, False, 0)
+        line0.pack_start(self.txt_searchdir, True, True, 0)
+        line0.pack_start(self.browse_button, False, False, 0)
+
         line1 = Gtk.HBox(False, 5)
-        line1.pack_start(lbl_searchdir, False, False, 5)
-        line1.pack_start(self.txt_searchdir, True, True, 0)
-        line1.pack_start(self.browse_button, False, False, 0)
+        line1.pack_start(lbl_library, False, False, 0)
+        line1.pack_start(self.chk_library_autoscan, False, False, 0)
+        line1.pack_start(self.chk_scan_whole_list, False, False, 0)
 
         line2 = Gtk.HBox(False, 5)
         line2.pack_start(lbl_process, False, False, 5)
@@ -2124,6 +2131,8 @@ class Settings(Gtk.Window):
         self.txt_player.set_text(self.engine.get_config('player'))
         self.txt_process.set_text(self.engine.get_config('tracker_process'))
         self.txt_searchdir.set_text(self.engine.get_config('searchdir'))
+        self.chk_library_autoscan.set_active(self.engine.get_config('library_autoscan'))
+        self.chk_scan_whole_list.set_active(self.engine.get_config('scan_whole_list'))
         self.txt_plex_host.set_text(self.engine.get_config('plex_host'))
         self.txt_plex_port.set_text(self.engine.get_config('plex_port'))
         self.chk_tracker_enabled.set_active(self.engine.get_config('tracker_enabled'))
@@ -2173,6 +2182,10 @@ class Settings(Gtk.Window):
         self.engine.set_config('player', self.txt_player.get_text())
         self.engine.set_config('tracker_process', self.txt_process.get_text())
         self.engine.set_config('searchdir', self.txt_searchdir.get_text())
+        self.engine.set_config('library_autoscan',
+                self.chk_library_autoscan.get_active())
+        self.engine.set_config('scan_whole_list',
+                self.chk_scan_whole_list.get_active())
         self.engine.set_config('plex_host', self.txt_plex_host.get_text())
         self.engine.set_config('plex_port', self.txt_plex_port.get_text())
         self.engine.set_config('tracker_enabled', self.chk_tracker_enabled.get_active())

--- a/trackma/ui/qtui.py
+++ b/trackma/ui/qtui.py
@@ -1192,7 +1192,6 @@ class Trackma(QMainWindow):
             self.worker_call('delete_show', self.r_generic, show)
 
     def s_scan_library(self):
-        self._busy(True)
         self.worker_call('scan_library', self.r_library_scanned)
 
     def s_altname(self):

--- a/trackma/ui/qtui.py
+++ b/trackma/ui/qtui.py
@@ -1824,6 +1824,7 @@ class SettingsDialog(QDialog):
         self.searchdir_browse = QPushButton('Browse...')
         self.searchdir_browse.clicked.connect(self.s_searchdir_browse)
         self.library_autoscan = QCheckBox()
+        self.scan_whole_list   = QCheckBox()
 
         g_playnext_layout = QGridLayout()
         g_playnext_layout.addWidget(QLabel('Player'),                    0, 0, 1, 1)
@@ -1834,6 +1835,8 @@ class SettingsDialog(QDialog):
         g_playnext_layout.addWidget(self.searchdir_browse,               1, 2, 1, 1)
         g_playnext_layout.addWidget(QLabel('Rescan Library at startup'), 2, 0, 1, 2)
         g_playnext_layout.addWidget(self.library_autoscan,               2, 2, 1, 1)
+        g_playnext_layout.addWidget(QLabel('Scan through whole list'),   3, 0, 1, 2)
+        g_playnext_layout.addWidget(self.scan_whole_list,                 3, 2, 1, 1)
 
         g_playnext.setLayout(g_playnext_layout)
 
@@ -2077,6 +2080,7 @@ class SettingsDialog(QDialog):
         self.player.setText(engine.get_config('player'))
         self.searchdir.setText(engine.get_config('searchdir'))
         self.library_autoscan.setChecked(engine.get_config('library_autoscan'))
+        self.scan_whole_list.setChecked(engine.get_config('scan_whole_list'))
         self.plex_host.setText(engine.get_config('plex_host'))
         self.plex_port.setText(engine.get_config('plex_port'))
 
@@ -2151,6 +2155,7 @@ class SettingsDialog(QDialog):
         engine.set_config('player',            self.player.text())
         engine.set_config('searchdir',         self.searchdir.text())
         engine.set_config('library_autoscan',  self.library_autoscan.isChecked())
+        engine.set_config('scan_whole_list', self.scan_whole_list.isChecked())
         engine.set_config('plex_host',         self.plex_host.text())
         engine.set_config('plex_port',         self.plex_port.text())
 

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -280,6 +280,7 @@ config_defaults = {
     'autosend_size': 5,
     'autosend_at_exit': True,
     'library_autoscan': True,
+    'scan_whole_list': False,
     'debug_disable_lock': True,
     'auto_status_change': True,
     'auto_status_change_if_scored': True,


### PR DESCRIPTION
Implements #181.

To recap this PR adds the following:
+ The engine now optionally scans the mediafolder for series from all non-completed statuses (PTW/On-    Hold/Dropped)
+ Added a setting that en- or disables this feature (disabled by default)
+ Added corresponding settings to the GUIs (including a missing 'scan lib at startup for GTK)
+ The GUI remains operable whilst scanning

The pros and cons of this feature have been discussed, but it's probably fine as it is? I made it an optional feature to begin with, it's there for those that want it, and if it's too much of a drain it can be turned off.

Since I've had little feedback I figured I'd file a PR anyway and let you decide whether to merge it now or if it still needs work

Possible things to improve:

- [ ] I could fairly easily further optimise things to only scan for Watching/PTW, but I didn't want to mess  with the datamodel for a single feature just yet. let me know if you think this is worth it.