### PR TITLE
Put the romaji title in the first position

### DIFF
--- a/trackma/lib/libkitsu.py
+++ b/trackma/lib/libkitsu.py
@@ -481,7 +481,7 @@ class libkitsu(lib):
             'id': int(media['id']),
             # TODO : Some shows actually don't have a canonicalTitle; this should be fixed in the future.
             # For now I'm just picking the romaji title in these cases.
-            'title':       attr['canonicalTitle'] or attr['titles']['en_jp'],
+            'title':       attr['titles']['en_jp'] or attr['canonicalTitle'] or attr['titles']['en'],
             'total':       total or 0,
             'image':       attr['posterImage']['small'],
             'image_thumb': attr['posterImage']['tiny'],
@@ -504,4 +504,3 @@ class libkitsu(lib):
         info['status'] = self._guess_status(info['start_date'], info['end_date'])
 
         return info
-


### PR DESCRIPTION
I've just put the romaji title in the first position.

Why? Because now trackma shows `Attack on Titan`, and I prefer to have the more knowing name `Shingeki no Kyojin`.

Thank you