### PR TITLE
Revert 5e22ac4

### DIFF
--- a/trackma/lib/libkitsu.py
+++ b/trackma/lib/libkitsu.py
@@ -481,7 +481,7 @@ class libkitsu(lib):
             'id': int(media['id']),
             # TODO : Some shows actually don't have a canonicalTitle; this should be fixed in the future.
             # For now I'm just picking the romaji title in these cases.
-            'title':       attr['titles']['en_jp'] or attr['canonicalTitle'] or attr['titles']['en'],
+            'title':       attr['canonicalTitle'] or attr['titles']['en_jp'],
             'total':       total or 0,
             'image':       attr['posterImage']['small'],
             'image_thumb': attr['posterImage']['tiny'],


### PR DESCRIPTION
Because I have this error:

```
Traceback (most recent call last):
  File "/usr/lib64/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.5/threading.py", line 862, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3.5/site-packages/Trackma-0.7.3-py3.5.egg/trackma/ui/gtkui.py", line 842, in task_start_engine
    self.engine.start()
  File "/usr/lib/python3.5/site-packages/Trackma-0.7.3-py3.5.egg/trackma/engine.py", line 236, in start
    (self.api_info, self.mediainfo) = self.data_handler.start()
  File "/usr/lib/python3.5/site-packages/Trackma-0.7.3-py3.5.egg/trackma/data.py", line 173, in start
    self.download_data()
  File "/usr/lib/python3.5/site-packages/Trackma-0.7.3-py3.5.egg/trackma/data.py", line 532, in download_data
    self.showlist = self.api.fetch_list()
  File "/usr/lib/python3.5/site-packages/Trackma-0.7.3-py3.5.egg/trackma/lib/libkitsu.py", line 314, in fetch_list
    info = self._parse_info(media)
  File "/usr/lib/python3.5/site-packages/Trackma-0.7.3-py3.5.egg/trackma/lib/libkitsu.py", line 484, in _parse_info
    'title':       attr['titles']['en_jp'] or attr['canonicalTitle'] or attr['titles']['en'],
KeyError: 'en_jp'
```

So I think smetimes show doesn't have `en_jp`?

Sorry and thank you @z411 