### PR TITLE
Fix typo, fix isinstance() call

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -184,7 +184,7 @@ class Engine:
 
     def _get_tracker_list(self, filter_num=None):
         tracker_list = []
-        if isinstance(fliter_num, None):
+        if isinstance(filter_num, type(None)):
             source_list = self.get_list()
         elif isinstance(filter_num, list):
             source_list = []


### PR DESCRIPTION
Not sure how this made it into master but it totally borks the whole thing for me since latest pull.  This *may* be because I'm on python 3.6.2, don't have time to test on other versions though.  Anyhow, this fixes it for me, or so it seems.