### PR TITLE
Small fixes to GTK and Qt search view sorting

### DIFF
--- a/trackma/ui/gtkui.py
+++ b/trackma/ui/gtkui.py
@@ -2636,7 +2636,7 @@ class ShowSearchView(Gtk.TreeView):
         Gtk.TreeView.__init__(self)
 
         self.cols = dict()
-        i = 0
+        i = 1
         for name in ('Title', 'Type', 'Total'):
             self.cols[name] = Gtk.TreeViewColumn(name)
             self.cols[name].set_sort_column_id(i)

--- a/trackma/ui/qtui.py
+++ b/trackma/ui/qtui.py
@@ -1673,6 +1673,7 @@ class AddDialog(QDialog):
         # Create table
         columns = ['Title', 'Type', 'Total']
         self.table = QTableWidget()
+        self.table.setSortingEnabled(True)
         self.table.setColumnCount(len(columns))
         self.table.setHorizontalHeaderLabels(columns)
         self.table.horizontalHeader().setHighlightSections(False)


### PR DESCRIPTION
e81db16 fixes the sort IDs in GTK. They should start from 1 because the ID of Title column is 1.
94b15c8 enables sorting in Qt.

The sorting is still kind of wonky for the Total field because the values are number strings.