### PR TITLE
Qt - Update row colors when scanning whole list (fixes #314)

### DIFF
--- a/trackma/ui/qtui.py
+++ b/trackma/ui/qtui.py
@@ -718,15 +718,25 @@ class Trackma(QMainWindow):
 
         i = 0
 
-        if status == self.worker.engine.mediainfo['status_start']:
-            for show in showlist:
-                self._update_row( widget, i, show, altnames.get(show['id']), library.get(show['id']) )
-                i += 1
+        if not self.worker.engine.config['scan_whole_list']:
+            if status == self.worker.engine.mediainfo['status_start']:
+                for show in showlist:
+                    self._update_row( widget, i, show, altnames.get(show['id']), library.get(show['id']) )
+                    i += 1
+            else:
+                for show in showlist:
+                    self._update_row( widget, i, show, altnames.get(show['id']) )
+                    i += 1                    
         else:
-            for show in showlist:
-                self._update_row( widget, i, show, altnames.get(show['id']) )
-                i += 1
-
+            if status != self.worker.engine.mediainfo['status_finish']:
+                for show in showlist:
+                    self._update_row( widget, i, show, altnames.get(show['id']), library.get(show['id']) )
+                    i += 1
+            else:
+                for show in showlist:
+                    self._update_row( widget, i, show, altnames.get(show['id']) )
+                    i += 1                    
+            
         widget.setSortingEnabled(True)
         widget.sortByColumn(1, QtCore.Qt.AscendingOrder)
 


### PR DESCRIPTION
Fixes a bug where the list rows wouldn't be updated even with the 'Scan through whole list' option enabled, even though the files were detected.