### PR TITLE
curses: 256 color support

### DIFF
--- a/trackma/ui/curses.py
+++ b/trackma/ui/curses.py
@@ -23,6 +23,7 @@ except ImportError:
           "urwid package.")
     sys.exit(-1)
 
+import os
 import re
 import urwid
 import webbrowser
@@ -66,7 +67,7 @@ class Trackma_urwid():
 
         palette = []
         for k, color in self.config['palette'].items():
-            palette.append( (k, color[0], color[1]) )
+            palette.append(tuple([k] + color))
 
         # Prepare header
         sys.stdout.write("\x1b]0;Trackma-curses "+utils.VERSION+"\x07");
@@ -117,7 +118,13 @@ class Trackma_urwid():
         self.viewing_info = False
 
         self.view = urwid.Frame(self.listframe, header=self.top_pile, footer=self.statusbar)
-        self.mainloop = urwid.MainLoop(self.view, palette, unhandled_input=self.keystroke, screen=urwid.raw_display.Screen())
+
+        # Set up screen, enabling 256-color mode if the terminal supports it
+        screen = urwid.raw_display.Screen()
+        if os.environ['TERM'].endswith('-256color'):
+            screen.set_terminal_properties(colors=256)
+
+        self.mainloop = urwid.MainLoop(self.view, palette, unhandled_input=self.keystroke, screen=screen)
 
         self.mainloop.set_alarm_in(0, self.do_switch_account)
         self.mainloop.run()

--- a/trackma/ui/curses.py
+++ b/trackma/ui/curses.py
@@ -117,7 +117,7 @@ class Trackma_urwid():
 
         self.viewing_info = False
 
-        self.view = urwid.Frame(self.listframe, header=self.top_pile, footer=self.statusbar)
+        self.view = urwid.Frame(urwid.AttrMap(self.listframe, 'body'), header=self.top_pile, footer=self.statusbar)
 
         # Set up screen, enabling 256-color mode if the terminal supports it
         screen = urwid.raw_display.Screen()
@@ -470,13 +470,13 @@ class Trackma_urwid():
 
                 widgets.append( urwid.Padding(urwid.Text( linestr + "\n" ), left=3) )
 
-        self.view.body = urwid.Frame(urwid.ListBox(widgets), header=title)
+        self.view.body = urwid.AttrMap(urwid.Frame(urwid.ListBox(widgets), header=title), 'body')
         self.viewing_info = True
         self.status("Detail View | ESC:Return  Up/Down:Scroll  O:View website")
 
     def do_info_exit(self):
         if self.viewing_info:
-            self.view.body = self.listframe
+            self.view.body = urwid.AttrMap(self.listframe, 'body')
             self.viewing_info = False
             self.status("Ready.")
 


### PR DESCRIPTION
Adds support for 256 colors on terminals that support it.  Also fixes an issue where the 'body' display attributes aren't applied to blank space after the show list or on the details view (I'm assuming this was the intent of the 'body' attributes; if not I can add another set of attributes for this purpose).