### PR TITLE
[libanilist] Fix search possibly adding null names as show aliases

### DIFF
--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -370,10 +370,11 @@ fragment mediaListEntry on MediaList {
         for media in data:
             show = utils.show()
             showid = media['id']
+            aliases = [a for a in (media['title']['romaji'], media['title']['english'], media['title']['native']) if a]
             showdata = {
                 'id': showid,
                 'title': media['title']['userPreferred'],
-                'aliases': [media['title']['romaji'], media['title']['english'], media['title']['native']],
+                'aliases': aliases,
                 'type': media['format'],  # Need to reformat output
                 'status': self.status_translate[media['status']],
                 'total': self._c(media[self.total_str]),


### PR DESCRIPTION
Some shows on Anilist lack one or more titles.
Currently the `fetch_list` method accounts for this, only adding the names that exist as aliases, but the `search` method does not (my bad!), which passes `None`s to the aliases, causing a tracker crash if certain shows are added after a search with no list re-download.
I also noticed some other strangeness when adding new shows straight from a search (nonsensical error messages like "show not found" and the show still being added) but have not been able to reproduce them reliably, hopefully that was just another symptom of my oversight on this.