### PR TITLE
[QT, GTK] fixes for when PIL is unavailable

### DIFF
--- a/trackma/ui/gtkui.py
+++ b/trackma/ui/gtkui.py
@@ -1219,9 +1219,12 @@ class ImageTask(threading.Thread):
         req.add_header("User-agent", "TrackmaImage/{}".format(utils.VERSION))
         img_file = BytesIO(urllib.request.urlopen(req).read())
         if self.size:
-            im = Image.open(img_file)
-            im.thumbnail((self.size[0], self.size[1]), Image.ANTIALIAS)
-            im.save(self.local)
+            if imaging_available:
+                im = Image.open(img_file)
+                im.thumbnail((self.size[0], self.size[1]), Image.ANTIALIAS)
+                im.save(self.local)
+            else:
+                self.show_image.pholder_show("PIL library\nnot available")
         else:
             with open(self.local, 'wb') as f:
                 f.write(img_file.read())
@@ -1229,9 +1232,10 @@ class ImageTask(threading.Thread):
         if self.cancelled:
             return
 
-        Gdk.threads_enter()
-        self.show_image.image_show(self.local)
-        Gdk.threads_leave()
+        if os.path.exists(self.local):
+            Gdk.threads_enter()
+            self.show_image.image_show(self.local)
+            Gdk.threads_leave()
 
     def cancel(self):
         self.cancelled = True

--- a/trackma/ui/qtui.py
+++ b/trackma/ui/qtui.py
@@ -722,7 +722,7 @@ class Trackma(QMainWindow):
             else:
                 for show in showlist:
                     self._update_row( widget, i, show, altnames.get(show['id']) )
-                    i += 1                    
+                    i += 1
         else:
             if status != self.worker.engine.mediainfo['status_finish']:
                 for show in showlist:
@@ -731,8 +731,8 @@ class Trackma(QMainWindow):
             else:
                 for show in showlist:
                     self._update_row( widget, i, show, altnames.get(show['id']) )
-                    i += 1                    
-            
+                    i += 1
+
         widget.setSortingEnabled(True)
         widget.sortByColumn(self.config['sort_index'], self.config['sort_order'])
 
@@ -2943,9 +2943,10 @@ class Image_Worker(QtCore.QThread):
         try:
             img_file = BytesIO(urllib.request.urlopen(req).read())
             if self.size:
-                im = Image.open(img_file)
-                im.thumbnail((self.size[0], self.size[1]), Image.ANTIALIAS)
-                im.save(self.local)
+                if imaging_available:
+                    im = Image.open(img_file)
+                    im.thumbnail((self.size[0], self.size[1]), Image.ANTIALIAS)
+                    im.save(self.local)
             else:
                 with open(self.local, 'wb') as f:
                     f.write(img_file.read())


### PR DESCRIPTION
Fixes crashing for QT and an error from GTK when you don't have PIL installed and try to load a thumbnail.