### PR TITLE
libkitsu: add missing user start & finish dates

### DIFF
--- a/trackma/lib/libkitsu.py
+++ b/trackma/lib/libkitsu.py
@@ -306,6 +306,8 @@ class libkitsu(lib):
                         'my_progress': entry['attributes']['progress'],
                         'my_score': float(rating) if rating is not None else 0.0,
                         'my_status': entry['attributes']['status'],
+                        'my_start_date': self._iso2date(entry['attributes']['startedAt']),
+                        'my_finish_date': self._iso2date(entry['attributes']['finishedAt']),
                     })
 
                 if 'included' in data_json:
@@ -446,6 +448,16 @@ class libkitsu(lib):
         except:
             self.msg.debug(self.name, 'Invalid date {}'.format(string))
             return None # Ignore date if it's invalid
+
+    def _iso2date(self, string):
+        if string is None:
+            return None
+
+        try:
+            return datetime.datetime.strptime(string, "%Y-%m-%dT%H:%M:%S.%fZ").date()
+        except:
+            self.msg.debug(self.name, 'Invalid date {}'.format(string))
+            return None # Ignore date if it's invalid            
 
     def _guess_status(self, start_date, end_date):
         # Try to guess show status by checking start and end dates


### PR DESCRIPTION
Hello friends,
The current kitsu behaviour is to fetch only the series "start" and "finish" dates, but not the user timetables. This small addition adds the latter. Please double check as this is my first commit. >_<