### PR TITLE
Clean up trackers when unloading engines

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -216,6 +216,7 @@ class Engine:
         if self.loaded:
             self.msg.info(self.name, "Forcing exit...")
             self.data_handler.unload(True)
+            self.tracker.disable()
             self.loaded = False
 
     def connect_signal(self, signal, callback):
@@ -305,7 +306,7 @@ class Engine:
         if self.loaded:
             self.msg.info(self.name, "Unloading...")
             self.data_handler.unload()
-
+            self.tracker.disable()
             self.loaded = False
 
     def reload(self, account=None, mediatype=None):

--- a/trackma/tracker/inotify.py
+++ b/trackma/tracker/inotify.py
@@ -39,6 +39,9 @@ class inotifyTracker(inotifyBase.inotifyBase):
 
         try:
             for event in i.event_gen():
+                if not self.active:
+                    return
+
                 if event is not None:
                     # With inotifyx impl., only the event type was used,
                     # such that it only served to poll lsof when an

--- a/trackma/tracker/pyinotify.py
+++ b/trackma/tracker/pyinotify.py
@@ -75,13 +75,17 @@ class pyinotifyTracker(inotifyBase.inotifyBase):
             timeout = None
             while self.active:
                 if notifier.check_events(timeout):
+                    # Check again to avoid notifying while inactive
+                    if not self.active:
+                        return
+
                     notifier.read_events()
                     notifier.process_events()
                     if self.last_state == utils.TRACKER_NOVIDEO or self.last_updated:
                         timeout = None  # Block indefinitely
                     else:
                         timeout = 1000  # Check each second for counting
-                else:
+                elif self.active:
                     self.msg.debug(self.name, "Sending last state {} {}".format(self.last_state, self.last_show_tuple))
                     self.update_show_if_needed(self.last_state, self.last_show_tuple)
         finally:

--- a/trackma/tracker/tracker.py
+++ b/trackma/tracker/tracker.py
@@ -69,10 +69,8 @@ class TrackerBase(object):
         self.msg = message_handler
 
     def disable(self):
+        self.msg.info(self.name, 'Unloading...')
         self.active = False
-
-    def enable(self):
-        self.active = True
 
     def update_list(self, tracker_list):
         self.list = tracker_list


### PR DESCRIPTION
Fixes #382.

Call tracker.disable() when unloading engines.

Check tracker active state before reacting to incoming events.

Remove unused tracker.enable() method.