### PR TITLE
Don't attempt to disable engine.tracker when there is no tracker

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -216,7 +216,8 @@ class Engine:
         if self.loaded:
             self.msg.info(self.name, "Forcing exit...")
             self.data_handler.unload(True)
-            self.tracker.disable()
+            if self.tracker:
+                self.tracker.disable()
             self.loaded = False
 
     def connect_signal(self, signal, callback):
@@ -306,7 +307,8 @@ class Engine:
         if self.loaded:
             self.msg.info(self.name, "Unloading...")
             self.data_handler.unload()
-            self.tracker.disable()
+            if self.tracker:
+                self.tracker.disable()
             self.loaded = False
 
     def reload(self, account=None, mediatype=None):


### PR DESCRIPTION
Sorry, guess I didn't test changing from an account/media type without a tracker.