### PR TITLE
Fixed 1 issue of type: PYTHON_E225 throughout 1 file in repo.

### DIFF
--- a/trackma/tracker/plex.py
+++ b/trackma/tracker/plex.py
@@ -112,7 +112,7 @@ class PlexTracker(tracker.TrackerBase):
             return ''
 
         body = bytes('user[login]=%s&user[password]=%s' % (username, password), "utf-8")
-        headers={'X-Plex-Client-Identifier': uuid,
+        headers = {'X-Plex-Client-Identifier': uuid,
                 'X-Plex-Product': "Trackma",
                 'X-Plex-Version': utils.VERSION}
 


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.