### PR TITLE
trackma.tracker: Implement support for tracking via full paths

### DIFF
--- a/trackma/tracker/inotifyBase.py
+++ b/trackma/tracker/inotifyBase.py
@@ -79,7 +79,10 @@ class inotifyBase(tracker.TrackerBase):
             self._emit_signal('detected', path, name)
             self.open_file = (pathname, pid, fd)
 
-            (state, show_tuple) = self._get_playing_show(name)
+            if self.config['library_full_path']:
+                (state, show_tuple) = self._get_playing_show(pathname)
+            else:
+                (state, show_tuple) = self._get_playing_show(name)
             self.msg.debug(self.name, "Got status: {} {}".format(state, show_tuple))
             self.update_show_if_needed(state, show_tuple)
         else:

--- a/trackma/tracker/tracker.py
+++ b/trackma/tracker/tracker.py
@@ -55,6 +55,8 @@ class TrackerBase(object):
         self.list = tracker_list
         self.config = config
         self.redirections = redirections
+        # Reverse sorting for prefix matching
+        self.watch_dirs = tuple(sorted(watch_dirs, reverse=True))
         self.wait_s = None
 
         tracker_args = (config, watch_dirs)
@@ -195,6 +197,15 @@ class TrackerBase(object):
             return (utils.TRACKER_NOVIDEO, None)
 
         if filename:
+            # Trim out watch dir
+            if os.path.isabs(filename):
+                for watch_prefix in self.watch_dirs:
+                    if filename.startswith(watch_prefix):
+                        filename = filename[len(watch_prefix):]
+                        if filename.startswith(os.path.sep):
+                            filename = filename[len(os.path.sep):]
+                        break
+
             if filename == self.last_filename:
                 # It's the exact same filename, there's no need to do the processing again
                 return (self.last_state, self.last_show_tuple)


### PR DESCRIPTION
The tracker will now consider subdirectory names if the `library_full_paths` config setting is enabled. This fixes the bug with shows not being tracked if the names are only in the directories and not the files.