### PR TITLE
CLI: Don't crash on shlex errors i.e. unclosed quotes

### DIFF
--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -750,7 +750,12 @@ class Trackma_cmd(cmd.Cmd):
         elif cmd == 'help':
             return self.do_help(arg)
         else:
-            return self.execute(cmd, self.parse_args(arg), line)
+            try:
+                args = self.parse_args(arg)
+            except ValueError:
+                return self.default(line)
+            else:
+                return self.execute(cmd, args, line)
 
     def execute(self, cmd, args, line):
         try:


### PR DESCRIPTION
```
>> add "asd
Traceback (most recent call last):
  File "/home/fichte/code/trackma/trackma/ui/cli.py", line 718, in parse_args
    return shlex.split(arg)
  File "/usr/lib/python3.7/shlex.py", line 305, in split
    return list(lex)
  File "/usr/lib/python3.7/shlex.py", line 295, in __next__
    token = self.get_token()
  File "/usr/lib/python3.7/shlex.py", line 105, in get_token
    raw = self.read_token()
  File "/usr/lib/python3.7/shlex.py", line 187, in read_token
    raise ValueError("No closing quotation")
ValueError: No closing quotation
```