### PR TITLE
[CLI] Environment variable fix for #454

### DIFF
--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -289,7 +289,9 @@ def get_terminal_size(fd=1):
         hw = struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
     except:
         try:
-            hw = (os.environ['LINES'], os.environ['COLUMNS'])
+            width = int(os.environ.get('COLUMNS', 80))
+            height = int(os.environ.get('LINES', 25))
+            hw = (height, width)
         except:
             hw = (25, 80)
 


### PR DESCRIPTION
Fixes strings being erroneously passed to the rest of the program when LINES and COLUMNS are specified, as one might do for #454. Additionally, allows specifying COLUMNS without LINES (and vice-versa though that is not as useful).

The end result is that `COLUMNS=130 trackma list > list.txt` will produce expected output.