### PR TITLE
[Qt] Use doubleClicked signal and add success message box in add dialog

### DIFF
--- a/trackma/ui/qt/add.py
+++ b/trackma/ui/qt/add.py
@@ -22,7 +22,8 @@ from PyQt5 import QtCore, QtGui
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit,
     QPushButton, QTableView, QAbstractItemView, QHeaderView, QSpinBox,
-    QDialogButtonBox, QStackedWidget, QComboBox, QRadioButton, QSplitter)
+    QDialogButtonBox, QStackedWidget, QComboBox, QRadioButton, QSplitter,
+    QMessageBox)
 
 from trackma.ui.qt.details import DetailsDialog
 from trackma.ui.qt.widgets import AddTableDetailsView, AddCardView
@@ -207,3 +208,5 @@ class AddDialog(QDialog):
         if result['success']:
             if self.default:
                 self.accept()
+            else:
+                QMessageBox.information(self, 'Information', "Show added successfully")

--- a/trackma/ui/qt/add.py
+++ b/trackma/ui/qt/add.py
@@ -114,7 +114,7 @@ class AddDialog(QDialog):
         
         cardview = AddCardView(api_info=self.worker.engine.api_info)
         cardview.changed.connect(self.s_selected)
-        cardview.activated.connect(self.s_show_details)
+        cardview.doubleClicked.connect(self.s_show_details)
         
         self.contents.addWidget(cardview)
         self.contents.addWidget(tableview)

--- a/trackma/ui/qt/mainwindow.py
+++ b/trackma/ui/qt/mainwindow.py
@@ -289,7 +289,7 @@ class MainWindow(QMainWindow):
         self.view.selectionModel().currentRowChanged.connect(self.s_show_selected)
         self.view.itemDelegate().setBarStyle(self.config['episodebar_style'], self.config['episodebar_text'])
         self.view.middleClicked.connect(lambda: self.s_play(True))
-        self.view.activated.connect(self.s_show_details)
+        self.view.doubleClicked.connect(self.s_show_details)
         self._apply_view()
 
         self.view.model().sourceModel().progressChanged.connect(self.s_set_episode)


### PR DESCRIPTION
* Using `doubleClicked` signal as the `activated` signal is triggered inconsistently on different
platforms/settings.
Reference: https://doc.qt.io/qt-5/qabstractitemview.html#activated
*  Show a message box as feedback when a show is added

Fixes #461

