### PR TITLE
CLI: Show status in info instead of numeric value

### DIFF
--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -376,7 +376,10 @@ class Trackma_cmd(cmd.Cmd):
         print()
 
         for line in details['extra']:
-            print("%s: %s" % line)
+            if line[0] == 'Status':
+                print(f"{line[0]}: {utils.STATUS_DICT[line[1]]}")
+            else:
+                print("%s: %s" % line)
 
     def do_search(self, args):
         """

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -37,6 +37,15 @@ STATUS_NOTYET = 3
 STATUS_CANCELLED = 4
 STATUS_OTHER = 100
 
+STATUS_DICT = {
+    STATUS_UNKNOWN: 'Unknown',
+    STATUS_AIRING: 'Airing',
+    STATUS_FINISHED: 'Finished',
+    STATUS_NOTYET: 'Not yet aired',
+    STATUS_CANCELLED: 'Cancelled',
+    STATUS_OTHER: 'Other',
+}
+
 TYPE_UNKNOWN = 0
 TYPE_TV = 1
 TYPE_MOVIE = 2


### PR DESCRIPTION
When requesting the info of a tracked item, the CLI returns the internal value instead of a human-readable string.

Before
![20200224_185658](https://user-images.githubusercontent.com/1142101/75178650-c732c600-5738-11ea-85cf-f745006cc984.png)

After
![20200224_185725](https://user-images.githubusercontent.com/1142101/75178673-d3b71e80-5738-11ea-8d40-0bcd2c2a94e4.png)
