### PR TITLE
Fix some major and minor issues in Gtk UI.

### DIFF
--- a/trackma/data.py
+++ b/trackma/data.py
@@ -292,7 +292,7 @@ class Data:
                    }
             item[key] = value
             self.queue.append(item)
-            
+
         show['queued'] = True
 
         self._save_queue()

--- a/trackma/tracker/mpris.py
+++ b/trackma/tracker/mpris.py
@@ -43,7 +43,7 @@ class MPRISTracker(tracker.TrackerBase):
 
             sender = self.bus.get_name_owner(name)
             self.filenames[sender] = self._get_filename(metadata)
-        
+
             if not self.active_player:
                 self._handle_status(status, sender)
         else:
@@ -80,7 +80,7 @@ class MPRISTracker(tracker.TrackerBase):
             self.update_show_if_needed(state, show_tuple)
 
             self.msg.debug(self.name, "New tracker status: {} ({})".format(state, self.last_state))
-            
+
             # We can override the active player if this player is playing a valid show.
             if not self.active_player or self.last_state == utils.TRACKER_PLAYING:
                 self.msg.debug(self.name, "({}) Setting active player: {}".format(self.last_state, sender))
@@ -92,7 +92,7 @@ class MPRISTracker(tracker.TrackerBase):
 
                     self._pass_timer()
                     GLib.timeout_add_seconds(1, self._pass_timer)
-       
+
     def _stopped(self, sender):
         self.filenames[sender] = None
 
@@ -124,7 +124,7 @@ class MPRISTracker(tracker.TrackerBase):
                 self._handle_status(status, sender)
         else:
             self.msg.debug(self.name, "Got signal from an inactive player, ignoring.")
- 
+
     def _new_name(self, name, old, new):
         if name.startswith(MPRISTracker.mpris_base):
             if new:

--- a/trackma/ui/gtk/accountswindow.py
+++ b/trackma/ui/gtk/accountswindow.py
@@ -17,6 +17,8 @@
 import os
 import webbrowser
 from enum import Enum
+from gi import require_version
+require_version('Gtk', '3.0')
 from gi.repository import Gtk, GdkPixbuf, GObject
 from trackma.ui.gtk import gtk_dir
 from trackma.ui.gtk.gi_composites import GtkTemplate
@@ -35,9 +37,9 @@ class AccountsWindow(Gtk.Dialog):
     __gtype_name__ = 'AccountsWindow'
 
     __gsignals__ = {
-        'account-cancel': (GObject.SIGNAL_RUN_FIRST, None,
+        'account-cancel': (GObject.SignalFlags.RUN_FIRST, None,
                            ()),
-        'account-open': (GObject.SIGNAL_RUN_FIRST, None,
+        'account-open': (GObject.SignalFlags.RUN_FIRST, None,
                          (int, bool))
     }
 

--- a/trackma/ui/gtk/application.py
+++ b/trackma/ui/gtk/application.py
@@ -14,8 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import gi
-gi.require_version('Gtk', '3.0')
+from gi import require_version
+require_version('Gtk', '3.0')
 from gi.repository import GLib, Gio, Gtk
 from trackma.ui.gtk.window import TrackmaWindow
 from trackma import utils

--- a/trackma/ui/gtk/data/settingswindow.ui
+++ b/trackma/ui/gtk/data/settingswindow.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="adjustment_download_days">
@@ -163,12 +163,27 @@
                             <property name="receives_default">False</property>
                             <property name="draw_indicator">True</property>
                             <property name="group">radio_tracker_plex</property>
-                            <signal name="toggled" handler="_on_radio_tracker_local_toggled" swapped="no"/>
+                            <signal name="toggled" handler="_set_tracker_radio_buttons" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
                             <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkRadioButton" id="radio_tracker_mpris">
+                            <property name="label" translatable="yes">MPRIS</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">radio_tracker_plex</property>
+                            <signal name="toggled" handler="_set_tracker_radio_buttons" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
                           </packing>
                         </child>
                         <child>
@@ -320,7 +335,7 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
-                            <property name="position">1</property>
+                            <property name="position">2</property>
                           </packing>
                         </child>
                         <child>
@@ -375,7 +390,7 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                       </object>
@@ -399,7 +414,7 @@
                             <property name="receives_default">False</property>
                             <property name="draw_indicator">True</property>
                             <property name="group">radio_tracker_local</property>
-                            <signal name="toggled" handler="_on_radio_tracker_plex_toggled" swapped="no"/>
+                            <signal name="toggled" handler="_set_tracker_radio_buttons" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>

--- a/trackma/ui/gtk/gi_composites.py
+++ b/trackma/ui/gtk/gi_composites.py
@@ -20,6 +20,8 @@ from os.path import abspath, join
 
 import inspect
 import warnings
+from gi import require_version
+require_version('Gtk', '3.0')
 
 from gi.repository import Gio
 from gi.repository import GLib
@@ -267,4 +269,3 @@ class _GtkTemplate(object):
 #    GtkTemplate = lambda c: c
 #else:
 GtkTemplate = _GtkTemplate
-

--- a/trackma/ui/gtk/imagebox.py
+++ b/trackma/ui/gtk/imagebox.py
@@ -18,6 +18,8 @@ import os
 import threading
 import urllib.request
 from io import BytesIO
+from gi import require_version
+require_version('Gtk', '3.0')
 from gi.repository import GLib, Gtk, GdkPixbuf
 from trackma import utils
 

--- a/trackma/ui/gtk/mainview.py
+++ b/trackma/ui/gtk/mainview.py
@@ -139,6 +139,7 @@ class MainView(Gtk.Box):
         GLib.idle_add(self._update_widgets)
 
     def _engine_reload(self, account, mediatype):
+        self.set_buttons_sensitive(False)
         threading.Thread(target=self._engine_reload_task,
                          args=[account, mediatype]).start()
 

--- a/trackma/ui/gtk/mainview.py
+++ b/trackma/ui/gtk/mainview.py
@@ -395,7 +395,7 @@ class MainView(Gtk.Box):
         GLib.idle_add(self._prompt_update_next, show, played_ep)
 
     def _prompt_update_next(self, show, played_ep):
-        dialog = Gtk.MessageDialog(self,
+        dialog = Gtk.MessageDialog(self.get_toplevel(),
                                    Gtk.DialogFlags.MODAL,
                                    Gtk.MessageType.QUESTION,
                                    Gtk.ButtonsType.YES_NO,

--- a/trackma/ui/gtk/mainview.py
+++ b/trackma/ui/gtk/mainview.py
@@ -17,6 +17,8 @@
 import html
 import os
 import threading
+from gi import require_version
+require_version('Gtk', '3.0')
 from gi.repository import GLib, Gtk, Gdk, GObject
 from trackma.ui.gtk import gtk_dir
 from trackma.ui.gtk.gi_composites import GtkTemplate
@@ -33,11 +35,11 @@ class MainView(Gtk.Box):
     __gtype_name__ = 'MainView'
 
     __gsignals__ = {
-        'error': (GObject.SIGNAL_RUN_FIRST, None,
+        'error': (GObject.SignalFlags.RUN_FIRST, None,
                   (str, )),
-        'error-fatal': (GObject.SIGNAL_RUN_FIRST, None,
+        'error-fatal': (GObject.SignalFlags.RUN_FIRST, None,
                         (str,)),
-        'show-action': (GObject.SIGNAL_RUN_FIRST, None,
+        'show-action': (GObject.SignalFlags.RUN_FIRST, None,
                         (int, object)),
     }
 
@@ -497,11 +499,11 @@ class NotebookPage(Gtk.ScrolledWindow):
     __gtype_name__ = 'NotebookPage'
 
     __gsignals__ = {
-        'show-selected': (GObject.SIGNAL_RUN_FIRST, None,
+        'show-selected': (GObject.SignalFlags.RUN_FIRST, None,
                           (int, )),
-        'show-action': (GObject.SIGNAL_RUN_FIRST, None,
+        'show-action': (GObject.SignalFlags.RUN_FIRST, None,
                         (int, object)),
-        'column-toggled': (GObject.SIGNAL_RUN_FIRST, None,
+        'column-toggled': (GObject.SignalFlags.RUN_FIRST, None,
                            (str, bool)),
     }
 

--- a/trackma/ui/gtk/searchwindow.py
+++ b/trackma/ui/gtk/searchwindow.py
@@ -16,8 +16,8 @@
 
 import os
 import threading
-import gi
-gi.require_version('Gtk', '3.0')
+from gi import require_version
+require_version('Gtk', '3.0')
 from gi.repository import GLib, Gtk, GObject
 from trackma.ui.gtk import gtk_dir
 from trackma.ui.gtk.gi_composites import GtkTemplate

--- a/trackma/ui/gtk/settingswindow.py
+++ b/trackma/ui/gtk/settingswindow.py
@@ -15,6 +15,8 @@
 #
 
 import os
+from gi import require_version
+require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk, GObject, Pango
 from trackma.ui.gtk import gtk_dir
 from trackma.ui.gtk.statusicon import TrackmaStatusIcon

--- a/trackma/ui/gtk/settingswindow.py
+++ b/trackma/ui/gtk/settingswindow.py
@@ -50,6 +50,7 @@ class SettingsWindow(Gtk.Window):
     switch_tracker = GtkTemplate.Child()
 
     radio_tracker_local = GtkTemplate.Child()
+    radio_tracker_mpris = GtkTemplate.Child()
     entry_player_process = GtkTemplate.Child()
     btn_file_chooser_executable = GtkTemplate.Child()
     listbox_directories = GtkTemplate.Child()
@@ -128,6 +129,9 @@ class SettingsWindow(Gtk.Window):
             'progress_complete': self.colorbutton_progress_complete
         }
 
+        if os.sys.platform == 'linux':
+            self.radio_tracker_mpris.set_visible(True)
+
         self.radiobutton_download_days.connect("toggled", self._button_toggled, self.spinbutton_download_days)
         self.radiobutton_upload_minutes.connect("toggled", self._button_toggled, self.spinbutton_upload_minutes)
         self.radiobutton_upload_size.connect("toggled", self._button_toggled, self.spinbutton_upload_size)
@@ -144,6 +148,8 @@ class SettingsWindow(Gtk.Window):
 
         if self.engine.get_config('tracker_type') == 'local':
             self.radio_tracker_local.set_active(True)
+        elif self.engine.get_config('tracker_type') == 'mpris':
+                self.radio_tracker_mpris.set_active(True)
         elif self.engine.get_config('tracker_type') == 'plex':
             self.radio_tracker_plex.set_active(True)
 
@@ -231,6 +237,7 @@ class SettingsWindow(Gtk.Window):
     @GtkTemplate.Callback
     def _on_switch_tracker_state_set(self, switch, state):
         self.radio_tracker_local.set_sensitive(state)
+        self.radio_tracker_mpris.set_sensitive(state)
         self.radio_tracker_plex.set_sensitive(state)
 
         if state:
@@ -244,15 +251,8 @@ class SettingsWindow(Gtk.Window):
         self.checkbox_tracker_not_found_prompt.set_sensitive(state)
 
     @GtkTemplate.Callback
-    def _on_radio_tracker_local_toggled(self, radio_button):
-        self._set_tracker_radio_buttons()
-
-    @GtkTemplate.Callback
-    def _on_radio_tracker_plex_toggled(self, radio_button):
-        self._set_tracker_radio_buttons()
-
-    def _set_tracker_radio_buttons(self):
-        if self.radio_tracker_local.get_active():
+    def _set_tracker_radio_buttons(self, radio_button=None):
+        if self.radio_tracker_local.get_active() or self.radio_tracker_mpris.get_active():
             self._enable_local(True)
             self._enable_plex(False)
         else:
@@ -326,6 +326,8 @@ class SettingsWindow(Gtk.Window):
         # Tracker type
         if self.radio_tracker_local.get_active():
             self.engine.set_config('tracker_type', 'local')
+        elif self.radio_tracker_mpris.get_active():
+            self.engine.set_config('tracker_type', 'mpris')
         elif self.radio_tracker_plex.get_active():
             self.engine.set_config('tracker_type', 'plex')
 

--- a/trackma/ui/gtk/showinfobox.py
+++ b/trackma/ui/gtk/showinfobox.py
@@ -17,6 +17,8 @@
 import html
 import os
 import threading
+from gi import require_version
+require_version('Gtk', '3.0')
 from gi.repository import Gtk, GObject
 from trackma.ui.gtk import gtk_dir
 from trackma.ui.gtk.gi_composites import GtkTemplate
@@ -49,7 +51,7 @@ class ShowInfoBox(Gtk.Box):
         self.data_label = Gtk.Label('')
         self.data_label.set_line_wrap(True)
         self.data_label.set_property('selectable',True)
-        
+
         if isinstance(orientation, Gtk.Orientation):
             self.data_container.set_orientation(orientation)
         self.data_container.pack_start(self.data_label, True, True, 0)

--- a/trackma/ui/gtk/showinfowindow.py
+++ b/trackma/ui/gtk/showinfowindow.py
@@ -15,6 +15,8 @@
 #
 
 import os
+from gi import require_version
+require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk
 from trackma.ui.gtk import gtk_dir
 from trackma.ui.gtk.gi_composites import GtkTemplate

--- a/trackma/ui/gtk/showtreeview.py
+++ b/trackma/ui/gtk/showtreeview.py
@@ -13,13 +13,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
+from gi import require_version
+require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk, Pango, GObject
 from trackma import utils
 
 
 class ShowTreeView(Gtk.TreeView):
-    __gsignals__ = {'column-toggled': (GObject.SIGNAL_RUN_LAST, \
+    __gsignals__ = {'column-toggled': (GObject.SignalFlags.RUN_LAST, \
             GObject.TYPE_PYOBJECT, (GObject.TYPE_STRING, GObject.TYPE_BOOLEAN) )}
 
     def __init__(self, status, colors, visible_columns, progress_style=1, decimals=0):
@@ -284,19 +285,19 @@ class ProgressCellRenderer(Gtk.CellRenderer):
     __gproperties__ = {
         "value": (GObject.TYPE_INT, "Value",
                   "Progress percentage", 0, 1000, 0,
-                  GObject.PARAM_READWRITE),
+                  GObject.ParamFlags.READWRITE),
 
         "subvalue": (GObject.TYPE_INT, "Subvalue",
                      "Sub percentage", 0, 1000, 0,
-                     GObject.PARAM_READWRITE),
+                     GObject.ParamFlags.READWRITE),
 
         "total": (GObject.TYPE_INT, "Total",
                   "Total percentage", 0, 1000, 0,
-                  GObject.PARAM_READWRITE),
+                  GObject.ParamFlags.READWRITE),
 
         "eps": (GObject.TYPE_PYOBJECT, "Episodes",
                 "Available episodes",
-                GObject.PARAM_READWRITE),
+                GObject.ParamFlags.READWRITE),
     }
 
     def __init__(self, colors):
@@ -364,4 +365,3 @@ class ProgressCellRenderer(Gtk.CellRenderer):
     def __getColor(self, colorString):
         color = Gdk.color_parse(colorString)
         return color.red_float, color.green_float, color.blue_float
-

--- a/trackma/ui/gtk/statusicon.py
+++ b/trackma/ui/gtk/statusicon.py
@@ -13,7 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
+from gi import require_version
+require_version('Gtk', '3.0')
+require_version('Gdk', '3.0')
 from gi.repository import Gdk, Gtk, GObject
 from trackma import utils
 
@@ -22,11 +24,11 @@ class TrackmaStatusIcon(Gtk.StatusIcon):
     __gtype_name__ = 'TrackmaStatusIcon'
 
     __gsignals__ = {
-        'hide-clicked': (GObject.SIGNAL_RUN_FIRST, None,
+        'hide-clicked': (GObject.SignalFlags.RUN_FIRST, None,
                          ()),
-        'about-clicked': (GObject.SIGNAL_RUN_FIRST, None,
+        'about-clicked': (GObject.SignalFlags.RUN_FIRST, None,
                           ()),
-        'quit-clicked': (GObject.SIGNAL_RUN_FIRST, None,
+        'quit-clicked': (GObject.SignalFlags.RUN_FIRST, None,
                          ()),
     }
 

--- a/trackma/ui/gtk/window.py
+++ b/trackma/ui/gtk/window.py
@@ -18,6 +18,8 @@ import sys
 import os
 import subprocess
 import threading
+from gi import require_version
+require_version('Gtk', '3.0')
 from gi.repository import GLib, Gio, Gtk, Gdk
 from trackma.ui.gtk import gtk_dir
 from trackma.ui.gtk.gi_composites import GtkTemplate

--- a/trackma/ui/gtk/window.py
+++ b/trackma/ui/gtk/window.py
@@ -297,7 +297,7 @@ class TrackmaWindow(Gtk.ApplicationWindow):
         GLib.idle_add(self._main_view.populate_all_pages)
 
         self._main_view.set_status_idle("Ready.")
-        self._set_buttons_sensitive_idle(False)
+        self._set_buttons_sensitive_idle(True)
 
     def _on_accounts(self, action, param):
         self._show_accounts()
@@ -359,6 +359,7 @@ class TrackmaWindow(Gtk.ApplicationWindow):
         about.set_authors(["See AUTHORS file"])
         about.set_artists(["shuuichi"])
         about.connect('destroy', self._on_modal_destroy)
+        about.connect('response', lambda dialog, response: dialog.destroy())
         about.present()
         self._modals.append(about)
 


### PR DESCRIPTION
- Stop spinner on search failure.
- Update Headerbar subtitle and Results view to reflect search failure.
- Reenable UI after finishing 'Scan files' action.