### PR TITLE
CLI: Added optional range param to 'play' command for easier continuous play of show

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -881,7 +881,7 @@ class Engine:
             playep = int(playep)
             playto = int(playto)
         except ValueError:
-            raise utils.EngineError('Episode[s] must be numeric.')
+            raise utils.EngineError('Episode[s] must be numeric or with optional range (eg: 1-3, -3, or - to play all unseen episodes)')
 
         if show:
             playing_next = False

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -78,7 +78,7 @@ class Trackma_cmd(cmd.Cmd):
         'add':          1,
         'del':          1,
         'delete':       1,
-        'play':         (1, 2),
+        'play':         (1, 3),
         'openfolder':   1,
         'update':       (1, 2),
         'score':        2,
@@ -498,6 +498,7 @@ class Trackma_cmd(cmd.Cmd):
 
         :param show Episode index or title.
         :optparam ep Episode number. Assume next if not specified.
+        :optparam playto Episode number to play to in range.
         :usage play <show index or title> [episode number]
         """
         try:
@@ -508,8 +509,11 @@ class Trackma_cmd(cmd.Cmd):
             # otherwise play the next episode not watched yet
             if len(args) > 1:
                 episode = args[1]
+            playto = episode
+            if len(args) > 2:
+                playto = args[2]
 
-            self.engine.play_episode(show, episode)
+            self.engine.play_episode(show, episode, playto)
         except utils.TrackmaError as e:
             self.display_error(e)
 

--- a/trackma/ui/curses.py
+++ b/trackma/ui/curses.py
@@ -354,7 +354,7 @@ class Trackma_urwid():
         item = self._get_selected_item()
         if item:
             show = self.engine.get_show_info(item.showid)
-            self.ask('[Play] Episode # to play: ', self.play_request, show['my_progress']+1)
+            self.ask('[Play] Episodes to play (eg: 1, 1-3 or - to play all unseen): ', self.play_request, show['my_progress']+1)
 
     def do_openfolder(self):
         item = self._get_selected_item()


### PR DESCRIPTION
I have added @FichteFoll's suggestion of passing ranges of episodes to *play* function.
His examples:
> `play 12 1-` play show 12 from episode 1 onwards.
> `play 12 -` play show 12 from the next unseen episode onwards.
> `play 12 3-5` play episodes 3 to 5.

Additionally:
> `play 12 1 10` is equal to `play 12 1-10`
> `play 12 -5` play show 12 from next unseen to 5

Now also works with curses but no with secondary optional parameter (eg: `play 12 1 10`)
only `play 12 1-10` and so on works.

Added some verbosity to curses dialog
> [Play] Episodes to play (eg: 1, 1-3 or - to play all unseen): 

Added clearer error message on wrong input to play_episode
> Episode[s] must be numeric or with optional range (eg: 1-3, -3, or - to play all unseen episodes)

Might be a bit to verbose, I'm open to suggestions.