### PR TITLE
Update Void Linux repository URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Trackma also has user-provided packages for several distributions.
 - **Fedora:** https://copr.fedoraproject.org/coprs/dyskette/trackma/
 - **Gentoo Linux:** http://gpo.zugaina.org/net-misc/trackma
 - **OpenSUSE:** http://download.opensuse.org/repositories/home:/Rethil/
-- **Void Linux:** https://github.com/voidlinux/void-packages/blob/master/srcpkgs/trackma/template
+- **Void Linux:** https://github.com/void-linux/void-packages/blob/master/srcpkgs/trackma/template
 
 A user from the community also is providing a Docker image:
 


### PR DESCRIPTION
Void Linux has change their github repository few years ago (see : https://wiki.voidlinux.org/Xbps-src)