### PR TITLE
Remove 'is' comparisons with literals

### DIFF
--- a/trackma/ui/qt/accounts.py
+++ b/trackma/ui/qt/accounts.py
@@ -140,11 +140,11 @@ class AccountDialog(QDialog):
             self._error("Please select an account.")
 
     def s_edit(self, index):
-        if   index is 1:
+        if index == 1:
             self.edit()
-        elif index is 2:
+        elif index == 2:
             self.delete()
-        elif index is 3:
+        elif index == 3:
             self.purge()
 
     def rebuild(self):
@@ -164,7 +164,7 @@ class AccountDialog(QDialog):
 
             i += 1
 
-        if pyqt_version is 5:
+        if pyqt_version == 5:
             self.table.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
         else:
             self.table.horizontalHeader().setResizeMode(0, QHeaderView.Stretch)
@@ -247,12 +247,12 @@ class AccountAddDialog(QDialog):
         self.setLayout(layout)
 
     def validate(self):
-        if len(self.username.text()) is 0:
-            if len(self.password.text()) is 0:
+        if len(self.username.text()) == 0:
+            if len(self.password.text()) == 0:
                 self._error('Please fill the credentials fields.')
             else:
                 self._error('Please fill the username field.')
-        elif len(self.password.text()) is 0:
+        elif len(self.password.text()) == 0:
             self._error('Please fill the password/PIN field.')
         else:
             self.accept()
@@ -262,7 +262,7 @@ class AccountAddDialog(QDialog):
             self.username.setText("")
             self.password.setText("")
 
-        if pyqt_version is 5:
+        if pyqt_version == 5:
             apiname = self.api.itemData(index)
         else:
             apiname = str(self.api.itemData(index))

--- a/trackma/ui/qt/add.py
+++ b/trackma/ui/qt/add.py
@@ -198,7 +198,7 @@ class AddDialog(QDialog):
             self.set_results(result['result'])
             
             """
-            if self.table.currentRow() is 0:  # Row number hasn't changed but the data probably has!
+            if self.table.currentRow() == 0:  # Row number hasn't changed but the data probably has!
                 self.s_show_selected(self.table.item(0, 0))
             self.table.setCurrentItem(self.table.item(0, 0))"""
         else:

--- a/trackma/ui/qt/mainwindow.py
+++ b/trackma/ui/qt/mainwindow.py
@@ -498,7 +498,7 @@ class MainWindow(QMainWindow):
     def closeEvent(self, event):
         if not self.started or not self.worker.engine.loaded:
             event.accept()
-            if pyqt_version is 5 and self.finish:
+            if pyqt_version == 5 and self.finish:
                 QApplication.instance().quit()
         elif self.config['show_tray'] and self.config['close_to_tray']:
             event.ignore()
@@ -756,7 +756,7 @@ class MainWindow(QMainWindow):
             if column not in self.api_config['visible_columns']:
                 self.view.setColumnHidden(i, True)
 
-        if pyqt_version is 5:
+        if pyqt_version == 5:
             self.view.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch)
             self.view.horizontalHeader().setSectionResizeMode(2, QHeaderView.Fixed)
             self.view.horizontalHeader().setSectionResizeMode(3, QHeaderView.Fixed)

--- a/trackma/ui/qt/settings.py
+++ b/trackma/ui/qt/settings.py
@@ -362,7 +362,7 @@ class SettingsDialog(QDialog):
             scrollable_page.setWidget(page)
             self.contents.addWidget(scrollable_page)
 
-        if pyqt_version is not 5:
+        if pyqt_version != 5:
             self.contents.layout().setMargin(0)
 
         # Bottom buttons
@@ -601,7 +601,7 @@ class SettingsDialog(QDialog):
         self.auto_status_change_if_scored.setEnabled(checked)
 
     def s_player_browse(self):
-        if pyqt_version is 5:
+        if pyqt_version == 5:
             self.player.setText(QFileDialog.getOpenFileName(caption='Choose player executable')[0])
         else:
             self.player.setText(QFileDialog.getOpenFileName(caption='Choose player executable'))

--- a/trackma/ui/qt/widgets.py
+++ b/trackma/ui/qt/widgets.py
@@ -160,7 +160,7 @@ class ShowsTableView(QTableView):
         self.setSelectionMode(QAbstractItemView.SingleSelection)
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.horizontalHeader().setHighlightSections(False)
-        if pyqt_version is 5:
+        if pyqt_version == 5:
             self.horizontalHeader().setSectionsMovable(True)
         else:
             self.horizontalHeader().setMovable(True)
@@ -239,7 +239,7 @@ class AddTableDetailsView(QSplitter):
         self.table.horizontalHeader().setSortIndicator(-1, QtCore.Qt.AscendingOrder)
         self.table.setSortingEnabled(True)
 
-        if pyqt_version is 5:
+        if pyqt_version == 5:
             self.table.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
         else:
             self.table.horizontalHeader().setResizeMode(0, QHeaderView.Stretch)


### PR DESCRIPTION
Became a SyntaxWarning in Python 3.8 and has been wrong since forever.