### PR TITLE
Unify ui module launching code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,9 @@ setup(
             'trackma-curses = trackma.ui.curses:main [curses]',
         ],
         'gui_scripts': [
-            'trackma-gtk = trackma.ui.gtk.main:main [GTK]',
+            'trackma-gtk = trackma.ui.gtk:main [GTK]',
             'trackma-qt = trackma.ui.qt:main [Qt]',
-            'trackma-qt4 = trackma.ui.qt.qt4ui:main [Qt]',
+            'trackma-qt4 = trackma.ui.qt.qt4:main [Qt4]',
         ]
     },
     classifiers=[

--- a/trackma/ui/gtk/__main__.py
+++ b/trackma/ui/gtk/__main__.py
@@ -14,19 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import os
 
-gtk_dir = os.path.dirname(__file__)
-
-
-def main():
-    import signal
-    import sys
-    from trackma import utils
-    from .application import TrackmaApplication
-
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
-
-    print("Trackma GTK v{}".format(utils.VERSION))
-    app = TrackmaApplication()
-    sys.exit(app.run(sys.argv))
+if __name__ == '__main__':
+    from . import main
+    main()

--- a/trackma/ui/qt/__init__.py
+++ b/trackma/ui/qt/__init__.py
@@ -16,74 +16,65 @@
 
 
 from trackma.ui.qt.mainwindow import MainWindow
-from trackma import messenger
 from trackma import utils
 import sys
 import os
 
-debug = False
-force_qt4 = False
 
+def main(force_qt4=False):
+    print("Trackma-qt v{}".format(utils.VERSION))
 
-print("Trackma-qt v{}".format(utils.VERSION))
+    debug = False
 
-if '-h' in sys.argv:
-    print("Usage: trackma-qt [options]")
-    print()
-    print('Options:')
-    print(' -d  Shows debugging information')
-    print(' -4  Force Qt4')
-    print(' -h  Shows this help')
-    sys.exit(0)
-if '-d' in sys.argv:
-    print('Showing debug information.')
-    debug = True
-if '-4' in sys.argv:
-    print('Forcing Qt4.')
-    force_qt4 = True
+    if '-h' in sys.argv:
+        print("Usage: trackma-qt [options]")
+        print()
+        print('Options:')
+        print(' -d  Shows debugging information')
+        print(' -4  Force Qt4')
+        print(' -h  Shows this help')
+        sys.exit(0)
+    if '-d' in sys.argv:
+        print('Showing debug information.')
+        debug = True
+    if '-4' in sys.argv:
+        print('Forcing Qt4.')
+        force_qt4 = True
 
-if not force_qt4:
+    if not force_qt4:
+        try:
+            from PyQt5.QtWidgets import QApplication, QMessageBox
+            os.environ['PYQT5'] = "1"
+        except ImportError:
+            print("Couldn't import Qt5 dependencies. "
+                  "Make sure you installed the PyQt5 package.")
+
+    if 'PYQT5' not in os.environ:
+        try:
+            import sip
+            sip.setapi('QVariant', 2)
+            from PyQt4.QtGui import QApplication, QMessageBox
+        except ImportError:
+            print("Couldn't import Qt4 dependencies. "
+                  "Make sure you installed the PyQt4 package.")
+            sys.exit(-1)
+
     try:
-        from PyQt5.QtWidgets import QApplication, QMessageBox
-        os.environ['PYQT5'] = "1"
-    except ImportError:
-        print("Couldn't import Qt5 dependencies. "
-              "Make sure you installed the PyQt5 package.")
-
-if 'PYQT5' not in os.environ:
-    try:
-        import sip
-        sip.setapi('QVariant', 2)
-        from PyQt4.QtGui import QApplication, QMessageBox
-    except ImportError:
-        print("Couldn't import Qt4 dependencies. "
-              "Make sure you installed the PyQt4 package.")
-        sys.exit(-1)
-
-
-try:
-    from PIL import Image
-    os.environ['imaging_available'] = "1"
-except ImportError:
-    try:
-        import Image
+        from PIL import Image
         os.environ['imaging_available'] = "1"
     except ImportError:
-        print("Warning: PIL or Pillow isn't available. "
-              "Preview images will be disabled.")
+        try:
+            import Image
+            os.environ['imaging_available'] = "1"
+        except ImportError:
+            print("Warning: PIL or Pillow isn't available. "
+                  "Preview images will be disabled.")
 
-
-def main():
     app = QApplication(sys.argv)
     app.setApplicationName("trackma")
     app.setDesktopFileName("trackma")
     try:
-        mainwindow = MainWindow(debug)
+        MainWindow(debug)
         sys.exit(app.exec_())
     except utils.TrackmaFatal as e:
-        QMessageBox.critical(None, 'Fatal Error',
-                             "{0}".format(e), QMessageBox.Ok)
-
-
-if __name__ == '__main__':
-    main()
+        QMessageBox.critical(None, 'Fatal Error', "{0}".format(e), QMessageBox.Ok)

--- a/trackma/ui/qt/__main__.py
+++ b/trackma/ui/qt/__main__.py
@@ -14,9 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import trackma.ui.qt
-import os
-os.environ['PYQT4'] = 'True'
-
 if __name__ == '__main__':
-    trackma.ui.qt.main()
+    from . import main
+    main()

--- a/trackma/ui/qt/qt4.py
+++ b/trackma/ui/qt/qt4.py
@@ -14,19 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import signal
-import sys
-from trackma.ui.gtk.application import TrackmaApplication
-from trackma import utils
-
-
-def main():
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
-
-    print("Trackma GTK v{}".format(utils.VERSION))
-    app = TrackmaApplication()
-    sys.exit(app.run(sys.argv))
-
-
 if __name__ == '__main__':
-    main()
+    from . import main
+    main(force_qt4=True)


### PR DESCRIPTION
By introducing a `__main__` submodule in the gtk and qt packages, the
respective UIs can be launched through `python -m trackma.ui.gtk`, just
like has already been possible with cli and curses.

The gtk main function is moved to the __init__ module just like for the
others.

qt4 loader file has been renamed to remove duplication in the module
path ('trackma.ui.qt.qt4ui').