### PR TITLE
Handle inotifyBase FileNotFoundError.

### DIFF
--- a/trackma/tracker/inotifyBase.py
+++ b/trackma/tracker/inotifyBase.py
@@ -43,11 +43,11 @@ class inotifyBase(tracker.TrackerBase):
 
             # Get process name
             try:
-		        with open('/proc/%s/cmdline' % p, 'rb') as f:
-		            cmdline = f.read()
-		            pname = cmdline.partition(b'\x00')[0]
-			except FileNotFoundError:
-				continue			# Continue without raising exception if process doesn't exist.
+                with open('/proc/%s/cmdline' % p, 'rb') as f:
+                    cmdline = f.read()
+                    pname = cmdline.partition(b'\x00')[0]
+            except FileNotFoundError:
+                continue            # Continue without raising exception if process doesn't exist.
             # It's not one of our players
             if not self.re_players.search(pname):
                 continue

--- a/trackma/tracker/inotifyBase.py
+++ b/trackma/tracker/inotifyBase.py
@@ -42,10 +42,12 @@ class inotifyBase(tracker.TrackerBase):
             if not p.isdigit(): continue
 
             # Get process name
-            with open('/proc/%s/cmdline' % p, 'rb') as f:
-                cmdline = f.read()
-                pname = cmdline.partition(b'\x00')[0]
-
+            try:
+		        with open('/proc/%s/cmdline' % p, 'rb') as f:
+		            cmdline = f.read()
+		            pname = cmdline.partition(b'\x00')[0]
+			except FileNotFoundError:
+				continue			# Continue without raising exception if process doesn't exist.
             # It's not one of our players
             if not self.re_players.search(pname):
                 continue

--- a/trackma/tracker/inotifyBase.py
+++ b/trackma/tracker/inotifyBase.py
@@ -47,7 +47,7 @@ class inotifyBase(tracker.TrackerBase):
                     cmdline = f.read()
                     pname = cmdline.partition(b'\x00')[0]
             except FileNotFoundError:
-                continue            # Continue without raising exception if process doesn't exist.
+                continue
             # It's not one of our players
             if not self.re_players.search(pname):
                 continue
@@ -141,4 +141,3 @@ class inotifyBase(tracker.TrackerBase):
 
         (state, show_tuple) = self._get_playing_show(None)
         self.update_show_if_needed(state, show_tuple)
-


### PR DESCRIPTION
Sometimes, a process ends before we open ther /proc/<pid> directory and open() throws a FileNotFoundError.
If this excpetion is raised, we will silently ignore the pid and continue the loop.