### PR TITLE
Qt: use `setExclusive` for backward compatibility

### DIFF
--- a/trackma/ui/qt/mainwindow.py
+++ b/trackma/ui/qt/mainwindow.py
@@ -245,7 +245,8 @@ class MainWindow(QMainWindow):
         menu_list.addAction(action_scan_library)
         menu_list.addAction(action_rescan_library)
         self.menu_mediatype = menubar.addMenu('&Mediatype')
-        self.mediatype_actiongroup = QActionGroup(self, exclusionPolicy=QActionGroup.ExclusionPolicy["Exclusive"])
+        self.mediatype_actiongroup = QActionGroup(self)
+        self.mediatype_actiongroup.setExclusive(True)
         self.mediatype_actiongroup.triggered.connect(self.s_mediatype)
         menu_options = menubar.addMenu('&Options')
         menu_options.addAction(self.action_reload)
@@ -309,7 +310,7 @@ class MainWindow(QMainWindow):
                             'my_end': 9,
                             'tag': 10}
 
-        self.menu_columns_group = QActionGroup(self, exclusionPolicy=QActionGroup.ExclusionPolicy["None"])
+        self.menu_columns_group = QActionGroup(self)
         self.menu_columns_group.triggered.connect(self.s_toggle_column)
 
         for i, column_name in enumerate(self.view.model().sourceModel().columns):


### PR DESCRIPTION
Fixes everything that https://github.com/z411/trackma/pull/468/commits/71f198a8da251d6b8eb94281317fa2c183743043 broke.