### PR TITLE
Kodi tracker support

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -986,6 +986,9 @@ class Engine:
         if ttype == 'plex':
             from trackma.tracker.plex import PlexTracker
             return PlexTracker
+        elif ttype == 'kodi':
+            from trackma.tracker.kodi import KodiTracker
+            return KodiTracker
         elif ttype == 'mpris':
             from trackma.tracker.mpris import MPRISTracker
             return MPRISTracker
@@ -1014,6 +1017,7 @@ class Engine:
             # Try trackers in this order: pyinotify, inotify, polling
             try:
                 return self._get_tracker_class('inotify_auto')
-            except ImportError:
+            except ImportError as e:
+                print(e)
                 return self._get_tracker_class('polling')
 

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -1017,7 +1017,6 @@ class Engine:
             # Try trackers in this order: pyinotify, inotify, polling
             try:
                 return self._get_tracker_class('inotify_auto')
-            except ImportError as e:
-                print(e)
+            except ImportError:
                 return self._get_tracker_class('polling')
 

--- a/trackma/tracker/kodi.py
+++ b/trackma/tracker/kodi.py
@@ -44,10 +44,11 @@ class KodiTracker(tracker.TrackerBase):
     def _get_kodi_status(self):
         # returns the status of the active players (if any)
         try:
-            player = self._get_rpc_info("Player.GetActivePlayers")[0]['type']
+            player = self._get_rpc_info("Player.GetActivePlayers")
 
-            if player == "video":
-                return ACTIVE
+            if player:
+                if player[0]['type'] == "video":
+                    return ACTIVE
             else:
                 return IDLE
         except urllib.request.URLError as e:

--- a/trackma/tracker/kodi.py
+++ b/trackma/tracker/kodi.py
@@ -1,0 +1,137 @@
+# This file is part of Trackma.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import time
+import json
+import urllib.request
+
+import trackma.utils as utils
+from trackma.tracker import tracker
+
+NOT_RUNNING = 0
+ACTIVE = 1
+PLAYING = 2
+PAUSED = 3
+IDLE = 4
+
+class KodiTracker(tracker.TrackerBase):
+    name = 'Tracker (Kodi)'
+
+    def __init__(self, messenger, tracker_list, config, watch_dirs, redirections=None):
+        self.config = config
+
+        self.host_port = self.config['kodi_host']+":"+self.config['kodi_port']
+        self.status_log = [None, None]
+        self.headers = {'content-type': 'application/json'}
+        super().__init__(messenger, tracker_list, config, watch_dirs, redirections)
+
+    def _get_kodi_status(self):
+        # returns the status of the active players (if any)
+        try:
+            active = self._get_rpc_info("Player.GetActivePlayers")
+
+            if active:
+                return ACTIVE
+            else:
+                return IDLE
+        except urllib.request.URLError:
+            return NOT_RUNNING
+
+    def _playing_file(self):
+        # returns the filename of the currently playing file
+        if self._get_kodi_status() == IDLE:
+            return None
+
+        name = self._get_rpc_info("Player.GetItem", { "playerid": 1 })['item']['label']
+        rstate = self._get_player_props("speed")
+        
+        if rstate > 0:
+            state = PLAYING
+        else:
+            state = PAUSED
+
+        return (name, state)
+
+    def _timer_from_file(self):
+        # returns 80% of video duration for the update timer,
+        # roughly the time of the video minus the OP and ED
+        if self._get_kodi_status() == IDLE:
+            return None
+
+        time = self._get_player_props("totaltime")
+        seconds = (time['hours']*3600)+(time['minutes']*60)+(time['seconds'])
+        
+        return round(seconds*0.80)
+
+    def _get_rpc_info(self, method, params={}):
+        url = "http://"+self.host_port+"/jsonrpc"
+
+        body = {
+            "method": method,
+            "params": params,
+            "jsonrpc": "2.0",
+            "id": 0
+        }
+
+        req = urllib.request.Request(url, json.dumps(body).encode(), headers=self.headers)
+        response = urllib.request.urlopen(req)
+        data = json.loads(response.read().decode())
+
+        return data['result']
+
+    def _get_player_props(self, prop):
+        # Get the required info from the player
+        props = {
+            "playerid": 1,
+            "properties": [prop]
+        }
+
+        info = self._get_rpc_info("Player.GetProperties", props)
+
+        return info[prop]
+    
+    def observe(self, config, watch_dirs):
+        self.msg.info(self.name, "Using Kodi.")
+
+        while self.active:
+            self.status_log.append(self._get_kodi_status())
+
+            if self.status_log[-1] == ACTIVE:
+                if self.status_log[-1] == IDLE and self.status_log[-2] == NOT_RUNNING:
+                    self.msg.info(self.name, "Reconnected to Kodi.")
+
+                if self.config['kodi_obey_update_wait_s']:
+                    self.wait_s = config['tracker_update_wait_s']
+                else:
+                    self.wait_s = self._timer_from_file()
+                    
+                player = self._playing_file()
+                (state, show_tuple) = self._get_playing_show(player[0])
+                
+                self.update_show_if_needed(state, show_tuple)
+                
+                if player[1] == PAUSED:
+                    self.pause_timer()
+                elif player[1] == PLAYING:
+                    self.resume_timer()
+
+            elif self.status_log[-1] == NOT_RUNNING and self.status_log[-2] == NOT_RUNNING:
+                self.msg.warn(self.name, "Kodi HTTP Server is not running.")
+
+            del self.status_log[0]
+
+            # Wait for the interval before running check again
+            time.sleep(config['tracker_interval'])

--- a/trackma/tracker/kodi.py
+++ b/trackma/tracker/kodi.py
@@ -44,9 +44,9 @@ class KodiTracker(tracker.TrackerBase):
     def _get_kodi_status(self):
         # returns the status of the active players (if any)
         try:
-            active = self._get_rpc_info("Player.GetActivePlayers")
+            player = self._get_rpc_info("Player.GetActivePlayers")[0]['type']
 
-            if active:
+            if player == "video":
                 return ACTIVE
             else:
                 return IDLE

--- a/trackma/tracker/kodi.py
+++ b/trackma/tracker/kodi.py
@@ -49,11 +49,16 @@ class KodiTracker(tracker.TrackerBase):
             if player:
                 if player[0]['type'] == "video":
                     return ACTIVE
+                else:
+                    return IDLE
             else:
                 return IDLE
         except urllib.request.URLError as e:
-            if e.code == 401:
-                return AUTH_REQUIRED
+            if hasattr(e, 'code'):
+                if e.code == 401:
+                    return AUTH_REQUIRED
+                else:
+                    return NOT_RUNNING
             else:
                 return NOT_RUNNING
 

--- a/trackma/ui/gtk/data/settingswindow.ui
+++ b/trackma/ui/gtk/data/settingswindow.ui
@@ -407,7 +407,6 @@
                         <property name="position">1</property>
                       </packing>
                     </child>
-<!--                      -->
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>
@@ -569,7 +568,6 @@
                         <property name="position">2</property>
                       </packing>
                     </child>
-<!--                      -->
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>
@@ -731,7 +729,6 @@
                         <property name="position">3</property>
                       </packing>
                     </child>
-<!--                      -->
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>

--- a/trackma/ui/gtk/data/settingswindow.ui
+++ b/trackma/ui/gtk/data/settingswindow.ui
@@ -16,6 +16,13 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustment_kodi_port">
+    <property name="lower">-1</property>
+    <property name="upper">100000</property>
+    <property name="value">8080</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustment_tracker_update_wait">
     <property name="upper">500</property>
     <property name="value">5</property>
@@ -400,6 +407,7 @@
                         <property name="position">1</property>
                       </packing>
                     </child>
+<!--                      -->
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>
@@ -561,6 +569,169 @@
                         <property name="position">2</property>
                       </packing>
                     </child>
+<!--                      -->
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">9</property>
+                        <child>
+                          <object class="GtkRadioButton" id="radio_tracker_kodi">
+                            <property name="label" translatable="yes">Kodi</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">radio_tracker_local</property>
+                            <signal name="toggled" handler="_set_tracker_radio_buttons" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkGrid">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="row_spacing">9</property>
+                            <property name="column_spacing">9</property>
+                            <property name="column_homogeneous">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Port</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Host</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="entry_kodi_host">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="spin_kodi_port">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="halign">end</property>
+                                <property name="text" translatable="yes">32400</property>
+                                <property name="adjustment">adjustment_kodi_port</property>
+                                <property name="value">32400</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Password</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Username</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="entry_kodi_username">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="entry_kodi_password">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">3</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbox_kodi_obey_wait">
+                                <property name="label" translatable="yes">Use "wait before update" time</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+<!--                      -->
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>
@@ -693,7 +864,7 @@
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">3</property>
+                        <property name="position">4</property>
                       </packing>
                     </child>
                   </object>

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -391,6 +391,8 @@ config_defaults = {
     'kodi_host': "localhost",
     'kodi_port': "8080",
     'kodi_obey_update_wait_s': False,
+    'kodi_user': '',
+    'kodi_passwd': '',
     'use_hooks': True,
 }
 userconfig_defaults = {

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -88,6 +88,7 @@ available_trackers = [
     ('polling', 'Polling (lsof)'),
     ('mpris', 'MPRIS'),
     ('plex', 'Plex Media Server'),
+    ('kodi', 'Kodi'),
     ('win32', 'Win32'),
 ]
 
@@ -387,6 +388,9 @@ config_defaults = {
     'plex_user': '',
     'plex_passwd': '',
     'plex_uuid': str(uuid.uuid1()),
+    'kodi_host': "localhost",
+    'kodi_port': "8080",
+    'kodi_obey_update_wait_s': False,
     'use_hooks': True,
 }
 userconfig_defaults = {


### PR DESCRIPTION
Kodi tracking support, only works with the internal player (for now) and requires enabling `Settings -> Services -> Control -> Allow control of Kodi via HTTP` to work. 

Only tested with Kodi 18.8 but should work with any version that uses the [JSON-RPC API/v10](https://kodi.wiki/view/JSON-RPC_API/v10).