### PR TITLE
Fix some issues with the GTK GUI

### DIFF
--- a/trackma/ui/gtk/accountswindow.py
+++ b/trackma/ui/gtk/accountswindow.py
@@ -17,8 +17,7 @@
 import os
 import webbrowser
 from enum import Enum
-from gi import require_version
-require_version('Gtk', '3.0')
+
 from gi.repository import Gtk, GdkPixbuf, GObject
 from trackma.ui.gtk import gtk_dir
 from trackma.ui.gtk.gi_composites import GtkTemplate
@@ -37,10 +36,8 @@ class AccountsWindow(Gtk.Dialog):
     __gtype_name__ = 'AccountsWindow'
 
     __gsignals__ = {
-        'account-cancel': (GObject.SignalFlags.RUN_FIRST, None,
-                           ()),
-        'account-open': (GObject.SignalFlags.RUN_FIRST, None,
-                         (int, bool))
+        'account-cancel': (GObject.SignalFlags.RUN_FIRST, None, ()),
+        'account-open': (GObject.SignalFlags.RUN_FIRST, None, (int, bool))
     }
 
     header_bar = GtkTemplate.Child()
@@ -63,7 +60,7 @@ class AccountsWindow(Gtk.Dialog):
     btn_pin_request = GtkTemplate.Child()
 
     def __init__(self, manager, **kwargs):
-        Gtk.Window.__init__(self, **kwargs)
+        super().__init__(self, **kwargs)
         self.init_template()
 
         self.accounts = []
@@ -86,7 +83,8 @@ class AccountsWindow(Gtk.Dialog):
     def _add_separators(self):
         self.accounts_listbox.set_header_func(self._accounts_listbox_header_func, None)
 
-    def _accounts_listbox_header_func(self, row, before, user_data):
+    @staticmethod
+    def _accounts_listbox_header_func(row, before, _user_data):
         if before is None:
             row.set_header(None)
             return
@@ -322,15 +320,19 @@ class AccountsWindow(Gtk.Dialog):
             self._refresh_btn_edit_confirm()
 
     def _refresh_btn_new_confirm(self):
-        sensitive = (self._get_combo_active_api_name() and
-                     self.username_entry.get_text().strip() and
-                     self.password_entry.get_text())
+        sensitive = (
+            self._get_combo_active_api_name() and
+            self.username_entry.get_text().strip() and
+            self.password_entry.get_text()
+        )
 
         self.btn_new_confirm.set_sensitive(sensitive)
 
     def _refresh_btn_edit_confirm(self):
-        sensitive = (self.password_entry.get_text() and
-                     not self.account_edit['password'] == self.password_entry.get_text())
+        sensitive = (
+            self.password_entry.get_text() and
+            not self.account_edit['password'] == self.password_entry.get_text()
+        )
         self.btn_edit_confirm.set_sensitive(sensitive)
 
     def _add_account(self):

--- a/trackma/ui/gtk/application.py
+++ b/trackma/ui/gtk/application.py
@@ -16,6 +16,7 @@
 
 from gi import require_version
 require_version('Gtk', '3.0')
+
 from gi.repository import GLib, Gio, Gtk
 from trackma.ui.gtk.window import TrackmaWindow
 from trackma import utils
@@ -25,13 +26,16 @@ class TrackmaApplication(Gtk.Application):
     __gtype_name__ = 'TrackmaApplication'
 
     def __init__(self):
-        super().__init__(application_id="com.github.z411.TrackmaGtk",
-                         flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE|Gio.ApplicationFlags.NON_UNIQUE)
+        super().__init__(
+            application_id="com.github.z411.TrackmaGtk",
+            flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE | Gio.ApplicationFlags.NON_UNIQUE
+        )
 
         self.debug = False
         self.window = None
-        self.add_main_option("debug", ord("d"), GLib.OptionFlags.NONE,
-                             GLib.OptionArg.NONE, "Show debugging information", None)
+        self.add_main_option(
+            "debug", ord("d"), GLib.OptionFlags.NONE, GLib.OptionArg.NONE, "Show debugging information", None
+        )
 
     def do_startup(self):
         Gtk.Application.do_startup(self)
@@ -88,11 +92,15 @@ class TrackmaApplication(Gtk.Application):
         if not self.window._engine:
             self.window.init_account_selection()
 
-    def message_error(self, error):
-        md = Gtk.MessageDialog(None,
-                           Gtk.DialogFlags.DESTROY_WITH_PARENT,
-                           Gtk.MessageType.ERROR,
-                           Gtk.ButtonsType.CLOSE, str(error))
+    @staticmethod
+    def message_error(error):
+        md = Gtk.MessageDialog(
+            None,
+            Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            Gtk.MessageType.ERROR,
+            Gtk.ButtonsType.CLOSE,
+            str(error)
+        )
         md.run()
         md.destroy()
 

--- a/trackma/ui/gtk/data/accountrow.ui
+++ b/trackma/ui/gtk/data/accountrow.ui
@@ -10,8 +10,8 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="valign">center</property>
-        <property name="margin_left">9</property>
-        <property name="margin_right">9</property>
+        <property name="margin_start">9</property>
+        <property name="margin_end">9</property>
         <property name="margin_top">9</property>
         <property name="margin_bottom">9</property>
         <property name="spacing">9</property>

--- a/trackma/ui/gtk/data/accountrow.ui
+++ b/trackma/ui/gtk/data/accountrow.ui
@@ -19,7 +19,7 @@
           <object class="GtkImage" id="account_logo">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="stock">gtk-missing-image</property>
+            <property name="icon_name">image-missing</property>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/trackma/ui/gtk/data/accountswindow.ui
+++ b/trackma/ui/gtk/data/accountswindow.ui
@@ -127,8 +127,8 @@
                             <property name="can_focus">False</property>
                             <property name="halign">center</property>
                             <property name="valign">center</property>
-                            <property name="margin_left">18</property>
-                            <property name="margin_right">18</property>
+                            <property name="margin_start">18</property>
+                            <property name="margin_end">18</property>
                             <property name="margin_top">18</property>
                             <property name="margin_bottom">18</property>
                             <property name="label_xalign">0</property>
@@ -283,8 +283,8 @@
                 <property name="width_request">250</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_left">18</property>
-                <property name="margin_right">18</property>
+                <property name="margin_start">18</property>
+                <property name="margin_end">18</property>
                 <property name="margin_top">36</property>
                 <property name="margin_bottom">36</property>
                 <property name="orientation">vertical</property>

--- a/trackma/ui/gtk/data/mainview.ui
+++ b/trackma/ui/gtk/data/mainview.ui
@@ -1,7 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="image1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">object-select-symbolic</property>
+  </object>
+  <object class="GtkPopover" id="entry_popover">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_start">8</property>
+        <property name="margin_end">8</property>
+        <property name="margin_top">8</property>
+        <property name="margin_bottom">8</property>
+        <property name="spacing">6</property>
+        <child>
+          <object class="GtkEntry" id="entry_episode">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="entry_done">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="image">image1</property>
+            <style>
+              <class name="suggested-action"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
   <object class="GtkAdjustment" id="score_adjustment">
     <property name="upper">100</property>
     <property name="step_increment">1</property>
@@ -18,17 +64,17 @@
   <template class="MainView" parent="GtkBox">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="margin_left">9</property>
-    <property name="margin_right">9</property>
-    <property name="margin_top">9</property>
-    <property name="margin_bottom">9</property>
+    <property name="margin_start">18</property>
+    <property name="margin_end">18</property>
+    <property name="margin_top">18</property>
+    <property name="margin_bottom">18</property>
     <property name="orientation">vertical</property>
-    <property name="spacing">9</property>
+    <property name="spacing">12</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="spacing">9</property>
+        <property name="spacing">12</property>
         <child>
           <object class="GtkLabel" id="show_title">
             <property name="visible">True</property>
@@ -52,7 +98,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">end</property>
-            <property name="spacing">9</property>
+            <property name="spacing">8</property>
             <child>
               <object class="GtkImage" id="api_icon">
                 <property name="visible">True</property>
@@ -96,7 +142,7 @@
       <object class="GtkBox" id="top_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="spacing">9</property>
+        <property name="spacing">12</property>
         <child>
           <object class="GtkBox" id="image_container_box">
             <property name="visible">True</property>
@@ -116,8 +162,8 @@
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="row_spacing">9</property>
-            <property name="column_spacing">9</property>
+            <property name="row_spacing">6</property>
+            <property name="column_spacing">12</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
@@ -168,82 +214,6 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="spacing">9</property>
-                <child>
-                  <object class="GtkButton" id="btn_episode_remove">
-                    <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">list-remove-symbolic</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="btn_episode_show_entry">
-                    <property name="label" translatable="yes">-</property>
-                    <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="entry_episode">
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="btn_episode_add">
-                    <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">list-add-symbolic</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">4</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkSpinButton" id="spinbtn_score">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
@@ -285,6 +255,72 @@
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButtonBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="layout_style">expand</property>
+                <child>
+                  <object class="GtkButton" id="btn_episode_remove">
+                    <property name="visible">True</property>
+                    <property name="sensitive">False</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">list-remove-symbolic</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="btn_episode_show_entry">
+                    <property name="label" translatable="yes">-</property>
+                    <property name="visible">True</property>
+                    <property name="sensitive">False</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                    <property name="non_homogeneous">True</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="btn_episode_add">
+                    <property name="visible">True</property>
+                    <property name="sensitive">False</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">list-add-symbolic</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
               </packing>
             </child>
             <child>

--- a/trackma/ui/gtk/data/mainview.ui
+++ b/trackma/ui/gtk/data/mainview.ui
@@ -57,7 +57,7 @@
               <object class="GtkImage" id="api_icon">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="stock">gtk-missing-image</property>
+                <property name="icon_name">image-missing</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -182,7 +182,7 @@
                       <object class="GtkImage">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="stock">gtk-remove</property>
+                        <property name="icon_name">list-remove-symbolic</property>
                       </object>
                     </child>
                   </object>
@@ -227,7 +227,7 @@
                       <object class="GtkImage">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="stock">gtk-add</property>
+                        <property name="icon_name">list-add-symbolic</property>
                       </object>
                     </child>
                   </object>

--- a/trackma/ui/gtk/data/settingswindow.ui
+++ b/trackma/ui/gtk/data/settingswindow.ui
@@ -83,8 +83,8 @@
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">18</property>
-                    <property name="margin_right">18</property>
+                    <property name="margin_start">18</property>
+                    <property name="margin_end">18</property>
                     <property name="margin_top">18</property>
                     <property name="margin_bottom">18</property>
                     <property name="orientation">vertical</property>
@@ -716,8 +716,8 @@
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_left">18</property>
-            <property name="margin_right">18</property>
+            <property name="margin_start">18</property>
+            <property name="margin_end">18</property>
             <property name="margin_top">18</property>
             <property name="margin_bottom">18</property>
             <property name="orientation">vertical</property>
@@ -745,7 +745,7 @@
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">12</property>
+                    <property name="margin_start">12</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
@@ -865,7 +865,7 @@
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">12</property>
+                    <property name="margin_start">12</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
@@ -1050,7 +1050,7 @@
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">12</property>
+                    <property name="margin_start">12</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
@@ -1073,7 +1073,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="margin_left">27</property>
+                        <property name="margin_start">27</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -1133,8 +1133,8 @@
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_left">18</property>
-            <property name="margin_right">18</property>
+            <property name="margin_start">18</property>
+            <property name="margin_end">18</property>
             <property name="margin_top">18</property>
             <property name="margin_bottom">18</property>
             <property name="orientation">vertical</property>
@@ -1191,7 +1191,7 @@
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">18</property>
+                    <property name="margin_start">18</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
@@ -1273,7 +1273,7 @@
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">6</property>
+                    <property name="margin_start">6</property>
                     <property name="spacing">9</property>
                     <property name="homogeneous">True</property>
                     <child>
@@ -1461,7 +1461,7 @@
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">6</property>
+                    <property name="margin_start">6</property>
                     <property name="spacing">9</property>
                     <property name="homogeneous">True</property>
                     <child>

--- a/trackma/ui/gtk/gi_composites.py
+++ b/trackma/ui/gtk/gi_composites.py
@@ -20,8 +20,6 @@ from os.path import abspath, join
 
 import inspect
 import warnings
-from gi import require_version
-require_version('Gtk', '3.0')
 
 from gi.repository import Gio
 from gi.repository import GLib

--- a/trackma/ui/gtk/imagebox.py
+++ b/trackma/ui/gtk/imagebox.py
@@ -96,7 +96,7 @@ class ImageBox(Gtk.HBox):
 
     def reset(self):
         if imaging_available:
-            self.set_text("Trackma")
+            self.set_image(utils.DATADIR + '/icon.png')
         else:
             self.set_text("PIL library\nnot available")
 

--- a/trackma/ui/gtk/imagebox.py
+++ b/trackma/ui/gtk/imagebox.py
@@ -18,8 +18,7 @@ import os
 import threading
 import urllib.request
 from io import BytesIO
-from gi import require_version
-require_version('Gtk', '3.0')
+
 from gi.repository import GLib, Gtk, GdkPixbuf
 from trackma import utils
 

--- a/trackma/ui/gtk/main.py
+++ b/trackma/ui/gtk/main.py
@@ -23,7 +23,7 @@ from trackma import utils
 def main():
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    print("Trackma-gtk v{}".format(utils.VERSION))
+    print("Trackma GTK v{}".format(utils.VERSION))
     app = TrackmaApplication()
     sys.exit(app.run(sys.argv))
 

--- a/trackma/ui/gtk/mainview.py
+++ b/trackma/ui/gtk/mainview.py
@@ -50,7 +50,9 @@ class MainView(Gtk.Box):
     api_user = GtkTemplate.Child()
     btn_episode_remove = GtkTemplate.Child()
     btn_episode_show_entry = GtkTemplate.Child()
+    entry_popover = GtkTemplate.Child()
     entry_episode = GtkTemplate.Child()
+    entry_done = GtkTemplate.Child()
     btn_episode_add = GtkTemplate.Child()
     btn_play_next = GtkTemplate.Child()
     spinbtn_score = GtkTemplate.Child()
@@ -106,7 +108,8 @@ class MainView(Gtk.Box):
         self.btn_episode_remove.connect("clicked", self._on_btn_episode_remove_clicked)
         self.btn_episode_show_entry.connect("clicked", self._show_episode_entry)
         self.entry_episode.connect("activate", self._on_entry_episode_activate)
-        self.entry_episode.connect("focus-out-event", self._hide_episode_entry)
+        self.entry_done.connect("clicked", self._on_entry_episode_activate)
+        self.entry_popover.connect("focus-out-event", self._hide_episode_entry)
         self.btn_episode_add.connect("clicked", self._on_btn_episode_add_clicked)
         self.btn_play_next.connect("clicked", self._on_btn_play_next_clicked, True)
         self.spinbtn_score.connect("activate", self._on_spinbtn_score_activate)
@@ -189,6 +192,7 @@ class MainView(Gtk.Box):
         self.btn_play_next.set_sensitive(can_play)
         self.btn_episode_show_entry.set_sensitive(can_update)
         self.entry_episode.set_sensitive(can_update)
+        self.entry_done.set_sensitive(can_update)
         self.btn_episode_add.set_sensitive(can_update)
 
     def _create_notebook_pages(self):
@@ -292,6 +296,7 @@ class MainView(Gtk.Box):
             if self._engine.mediainfo['can_update']:
                 self.btn_episode_show_entry.set_sensitive(boolean)
                 self.entry_episode.set_sensitive(boolean)
+                self.entry_done.set_sensitive(boolean)
                 self.btn_episode_add.set_sensitive(boolean)
                 self.btn_episode_remove.set_sensitive(boolean)
 
@@ -304,10 +309,11 @@ class MainView(Gtk.Box):
                   ShowEventType.EPISODE_REMOVE,
                   (self._current_page.selected_show,))
 
-    def _show_episode_entry(self, *args):
-        self.btn_episode_show_entry.hide()
+    def _show_episode_entry(self, widget):
+        self.entry_popover.set_relative_to(widget)
+        self.entry_popover.set_position(Gtk.PositionType.BOTTOM)
         self.entry_episode.set_text(self.btn_episode_show_entry.get_label())
-        self.entry_episode.show()
+        self.entry_popover.show()
         self.entry_episode.grab_focus()
 
     def _on_entry_episode_activate(self, widget):
@@ -316,12 +322,12 @@ class MainView(Gtk.Box):
             self.emit('show-action',
                       ShowEventType.EPISODE_SET,
                       (self._current_page.selected_show, episode))
+            self._hide_episode_entry()
         except ValueError:
             pass
 
     def _hide_episode_entry(self, *args):
-        self.entry_episode.hide()
-        self.btn_episode_show_entry.show()
+        self.entry_popover.hide()
 
     def _on_btn_episode_add_clicked(self, widget):
         self.emit('show-action',
@@ -440,7 +446,6 @@ class MainView(Gtk.Box):
 
         # Episode selector
         self.btn_episode_show_entry.set_label(str(show['my_progress']))
-        self._hide_episode_entry()
 
         # Status selector
         for i in self.statusmodel:

--- a/trackma/ui/gtk/mainview.py
+++ b/trackma/ui/gtk/mainview.py
@@ -17,8 +17,7 @@
 import html
 import os
 import threading
-from gi import require_version
-require_version('Gtk', '3.0')
+
 from gi.repository import GLib, Gtk, Gdk, GObject
 from trackma.ui.gtk import gtk_dir
 from trackma.ui.gtk.gi_composites import GtkTemplate

--- a/trackma/ui/gtk/searchwindow.py
+++ b/trackma/ui/gtk/searchwindow.py
@@ -16,8 +16,7 @@
 
 import os
 import threading
-from gi import require_version
-require_version('Gtk', '3.0')
+
 from gi.repository import GLib, Gtk, GObject
 from trackma.ui.gtk import gtk_dir
 from trackma.ui.gtk.gi_composites import GtkTemplate

--- a/trackma/ui/gtk/settingswindow.py
+++ b/trackma/ui/gtk/settingswindow.py
@@ -15,8 +15,7 @@
 #
 
 import os
-from gi import require_version
-require_version('Gtk', '3.0')
+
 from gi.repository import Gtk, Gdk, GObject, Pango
 from trackma.ui.gtk import gtk_dir
 from trackma.ui.gtk.statusicon import TrackmaStatusIcon
@@ -399,8 +398,8 @@ class DirectoryRow(Gtk.ListBoxRow):
 
         self.set_activatable(False)
         self.set_margin_bottom(5)
-        self.set_margin_left(16)
-        self.set_margin_right(16)
+        self.set_margin_start(16)
+        self.set_margin_end(16)
         self.set_margin_top(5)
 
         self.add(box)

--- a/trackma/ui/gtk/settingswindow.py
+++ b/trackma/ui/gtk/settingswindow.py
@@ -289,8 +289,8 @@ class SettingsWindow(Gtk.Window):
         chooser_dialog = Gtk.FileChooserDialog('Select a directory',
                                                self.get_parent_window(),
                                                Gtk.FileChooserAction.OPEN,
-                                               (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                                                Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
+                                               ("_Cancel", Gtk.ResponseType.CANCEL,
+                                                "_Open", Gtk.ResponseType.OK))
         chooser_dialog.set_default_response(Gtk.ResponseType.OK)
         chooser_dialog.set_action(Gtk.FileChooserAction.SELECT_FOLDER)
 

--- a/trackma/ui/gtk/showinfobox.py
+++ b/trackma/ui/gtk/showinfobox.py
@@ -17,8 +17,7 @@
 import html
 import os
 import threading
-from gi import require_version
-require_version('Gtk', '3.0')
+
 from gi.repository import Gtk, GObject
 from trackma.ui.gtk import gtk_dir
 from trackma.ui.gtk.gi_composites import GtkTemplate

--- a/trackma/ui/gtk/showinfowindow.py
+++ b/trackma/ui/gtk/showinfowindow.py
@@ -15,8 +15,7 @@
 #
 
 import os
-from gi import require_version
-require_version('Gtk', '3.0')
+
 from gi.repository import Gtk, Gdk
 from trackma.ui.gtk import gtk_dir
 from trackma.ui.gtk.gi_composites import GtkTemplate

--- a/trackma/ui/gtk/showtreeview.py
+++ b/trackma/ui/gtk/showtreeview.py
@@ -13,8 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from gi import require_version
-require_version('Gtk', '3.0')
+
 from gi.repository import Gtk, Gdk, Pango, GObject
 from trackma import utils
 

--- a/trackma/ui/gtk/statusicon.py
+++ b/trackma/ui/gtk/statusicon.py
@@ -35,19 +35,19 @@ class TrackmaStatusIcon(Gtk.StatusIcon):
     def __init__(self):
         Gtk.StatusIcon.__init__(self)
         self.set_from_file(utils.DATADIR + '/icon.png')
-        self.set_tooltip_text('Trackma-gtk ' + utils.VERSION)
+        self.set_tooltip_text('Trackma GTK')
         self.connect('activate', self._tray_status_event)
         self.connect('popup-menu', self._tray_status_menu_event)
 
-    def _tray_status_event(self, widget):
+    def _tray_status_event(self, _widget):
         self.emit('hide-clicked')
 
-    def _tray_status_menu_event(self, icon, button, time):
+    def _tray_status_menu_event(self, _icon, button, time):
         # Called when the tray icon is right-clicked
         menu = Gtk.Menu()
         mb_show = Gtk.MenuItem("Show/Hide")
-        mb_about = Gtk.ImageMenuItem('About', Gtk.Image.new_from_icon_name(Gtk.STOCK_ABOUT, 0))
-        mb_quit = Gtk.ImageMenuItem('Quit', Gtk.Image.new_from_icon_name(Gtk.STOCK_QUIT, 0))
+        mb_about = Gtk.ImageMenuItem('About', Gtk.Image.new_from_icon_name("help-about", Gtk.IconSize.MENU))
+        mb_quit = Gtk.ImageMenuItem('Quit', Gtk.Image.new_from_icon_name("application-exit", Gtk.IconSize.MENU))
 
         mb_show.connect("activate", self._tray_status_event)
         mb_about.connect("activate", self._on_mb_about)
@@ -67,7 +67,8 @@ class TrackmaStatusIcon(Gtk.StatusIcon):
     def _on_mb_quit(self, menu_item):
         self.emit('quit-clicked')
 
-    def _pos(self, menu, icon):
+    @staticmethod
+    def _pos(menu, icon):
         return Gtk.StatusIcon.position_menu(menu, icon)
 
     @staticmethod

--- a/trackma/ui/gtk/statusicon.py
+++ b/trackma/ui/gtk/statusicon.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from gi import require_version
-require_version('Gtk', '3.0')
 require_version('Gdk', '3.0')
 from gi.repository import Gdk, Gtk, GObject
 from trackma import utils
@@ -24,12 +23,9 @@ class TrackmaStatusIcon(Gtk.StatusIcon):
     __gtype_name__ = 'TrackmaStatusIcon'
 
     __gsignals__ = {
-        'hide-clicked': (GObject.SignalFlags.RUN_FIRST, None,
-                         ()),
-        'about-clicked': (GObject.SignalFlags.RUN_FIRST, None,
-                          ()),
-        'quit-clicked': (GObject.SignalFlags.RUN_FIRST, None,
-                         ()),
+        'hide-clicked': (GObject.SignalFlags.RUN_FIRST, None, ()),
+        'about-clicked': (GObject.SignalFlags.RUN_FIRST, None, ()),
+        'quit-clicked': (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
     def __init__(self):

--- a/trackma/ui/gtk/window.py
+++ b/trackma/ui/gtk/window.py
@@ -75,7 +75,7 @@ class TrackmaWindow(Gtk.ApplicationWindow):
     def _init_widgets(self):
         Gtk.Window.set_default_icon_from_file(utils.DATADIR + '/icon.png')
         self.set_position(Gtk.WindowPosition.CENTER)
-        self.set_title('Trackma GTK')
+        self.set_title('Trackma')
 
         if self._config['remember_geometry']:
             self.resize(self._config['last_width'], self._config['last_height'])

--- a/trackma/ui/gtk/window.py
+++ b/trackma/ui/gtk/window.py
@@ -42,6 +42,7 @@ class TrackmaWindow(Gtk.ApplicationWindow):
 
     btn_appmenu = GtkTemplate.Child()
     btn_mediatype = GtkTemplate.Child()
+    header_bar = GtkTemplate.Child()
 
     def __init__(self, app, debug=False):
         Gtk.ApplicationWindow.__init__(self, application=app)
@@ -74,7 +75,7 @@ class TrackmaWindow(Gtk.ApplicationWindow):
     def _init_widgets(self):
         Gtk.Window.set_default_icon_from_file(utils.DATADIR + '/icon.png')
         self.set_position(Gtk.WindowPosition.CENTER)
-        self.set_title('Trackma-gtk ' + utils.VERSION)
+        self.set_title('Trackma GTK')
 
         if self._config['remember_geometry']:
             self.resize(self._config['last_width'], self._config['last_height'])
@@ -211,10 +212,8 @@ class TrackmaWindow(Gtk.ApplicationWindow):
         api_iconpath = 1
         api_iconfile = current_api[api_iconpath]
 
-        self.set_title('Trackma-gtk %s [%s (%s)]' % (
-            utils.VERSION,
-            self._engine.api_info['name'],
-            self._engine.api_info['mediatype']))
+        self.header_bar.set_subtitle(self._engine.api_info['name'] + " (" +
+                                     self._engine.api_info['mediatype'] + ")")
 
         if self.statusicon and self._config['tray_api_icon']:
             self.statusicon.set_from_file(api_iconfile)
@@ -222,7 +221,7 @@ class TrackmaWindow(Gtk.ApplicationWindow):
     def _on_change_mediatype(self, action, value):
         action.set_state(value)
         mediatype = value.get_string()
-        self._main_view.load_account_mediatype(None, mediatype)
+        self._main_view.load_account_mediatype(None, mediatype, self.header_bar)
 
     def _on_search(self, action, param):
         current_status = self._main_view.get_current_status()
@@ -332,27 +331,27 @@ class TrackmaWindow(Gtk.ApplicationWindow):
         # Reload the engine if already started,
         # start it otherwise
         if self._engine and self._engine.loaded:
-            self._main_view.load_account_mediatype(account, None)
+            self._main_view.load_account_mediatype(account, None, None)
         else:
             self._create_engine(account)
 
-    def _on_account_cancel(self, accounts_window, switch):
+    def _on_account_cancel(self, _accounts_window, switch):
         manager = AccountManager()
 
         if not switch or not manager.get_accounts():
             self._quit()
 
-    def _on_preferences(self, action, param):
+    def _on_preferences(self, _action, _param):
         win = SettingsWindow(self._engine, self._config, self._configfile, transient_for=self)
         win.connect('destroy', self._on_modal_destroy)
         win.present()
         self._modals.append(win)
 
-    def _on_about(self, action, param):
+    def _on_about(self, _action, _param):
         about = Gtk.AboutDialog(parent=self)
         about.set_modal(True)
         about.set_transient_for(self)
-        about.set_program_name("Trackma-gtk")
+        about.set_program_name("Trackma GTK")
         about.set_version(utils.VERSION)
         about.set_license_type(Gtk.License.GPL_3_0_ONLY)
         about.set_comments("Trackma is an open source client for media tracking websites.\nThanks to all contributors.")

--- a/trackma/ui/gtk/window.py
+++ b/trackma/ui/gtk/window.py
@@ -18,8 +18,7 @@ import sys
 import os
 import subprocess
 import threading
-from gi import require_version
-require_version('Gtk', '3.0')
+
 from gi.repository import GLib, Gio, Gtk, Gdk
 from trackma.ui.gtk import gtk_dir
 from trackma.ui.gtk.gi_composites import GtkTemplate


### PR DESCRIPTION
Made several changes that are not immediately visible. The commit messages are hopefully descriptive enough.

- Now uses a GtkPopover for setting episode number.
- Use a GtkButtonBox for the episode number, "+" and "-" buttons.
- Stop using "Gtk.STOCK_" items because they've been deprecated and use suggested alternatives from GTK docs.
- Library info (i.e. "Anilist [manga]") is now in the subtitle instead of the title and is now updated properly.
- Some spacings have been fixed to match the GNOME HIG and results in a more pleasant UI.

There are a few changes that are personal opinions and can be reverted if necessary:
- "Trackma-gtk" is less suited for use anywhere other than the CLI. So, I've renamed all instances of it within the UI to "Trackma GTK" and just "Trackma" in the application title. Now, it only mentions "GTK" in the About window and the stdout.
- Stop showing the version info in title bar because it's available in the About window anyway.

The UI looks like this now:  
![Screenshot from 2020-09-21 00-07-23](https://user-images.githubusercontent.com/28823274/93719220-a92e2680-fb9e-11ea-9089-069cf7bcf878.png)
