### PR TITLE
Ignore SIGCLD to prevent keeping zombie process.

### DIFF
--- a/trackma/ui/gtk/main.py
+++ b/trackma/ui/gtk/main.py
@@ -22,6 +22,7 @@ from trackma import utils
 
 def main():
     signal.signal(signal.SIGINT, signal.SIG_DFL)
+    signal.signal(signal.SIGCLD, signal.SIG_IGN)
 
     print("Trackma-gtk v{}".format(utils.VERSION))
     app = TrackmaApplication()


### PR DESCRIPTION
If we ignore SIGCLD then init(1) automatically reaps child process on exit and this fixes not getting player process close event on polling/inotify trackers.
Fixes #508