### PR TITLE
[Plex Tracker] Update state on plex video close

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -175,7 +175,7 @@ class Engine:
         for module in self.hooks_available:
             method = getattr(module, signal, None)
             if method is not None:
-                self.msg.info(self.name, "Calling hook {}:{}...".format(
+                self.msg.debug(self.name, "Calling hook {}:{}...".format(
                     module.__name__, signal))
                 try:
                     method(self, *args)

--- a/trackma/tracker/plex.py
+++ b/trackma/tracker/plex.py
@@ -124,7 +124,11 @@ class PlexTracker(tracker.TrackerBase):
                         elif player[1] == PLAYING:
                             self.resume_timer()
                 except IndexError:
-                    pass
+                    if self.status_log[-1] == IDLE:
+                        self.last_filename = None
+                        self.update_show_if_needed(0, None)
+                    else:
+                        pass
             elif self.status_log[-1] == CLAIMED and self.status_log[-2] == CLAIMED:
                 self.msg.warn(
                     self.name, "Claimed Plex Media Server, login in the settings and restart trackma.")


### PR DESCRIPTION
Found an issue while using the plex tracker where upon closing the video the tracker would not update, and would continue to think the video was playing. I implemented a quick and dirty fix to allow for the update to occur. I also made hook calls print in debug mode as tracker_state spams the screen every tracker_interval