### PR TITLE
Added Jellyfin Tracker Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The following media recognition trackers are available and their requirements ar
 | inotify | Instant, but only supported in Linux. Uses it whenever possible. | inotify *or* pyinotify |
 | Polling | Slow, but supported in every POSIX platform. Fallback. | lsof |
 | Plex | Connects to Plex server. Enabled manually. | None |
+| Jellyfin | Connects to Jellyfin server. Enabled manually. | None |
 | MPRIS | Connects to running MPRIS capable media players. | dbus-python |
 | Win32 | Recognition for Windows platforms. | None |
 

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -1067,6 +1067,9 @@ class Engine:
         if ttype == 'plex':
             from trackma.tracker.plex import PlexTracker
             return PlexTracker
+        if ttype == 'jellyfin':
+            from trackma.tracker.jellyfin import JellyfinTracker
+            return JellyfinTracker
         elif ttype == 'kodi':
             from trackma.tracker.kodi import KodiTracker
             return KodiTracker

--- a/trackma/tracker/jellyfin.py
+++ b/trackma/tracker/jellyfin.py
@@ -12,7 +12,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
+
+# TODO: Add gui stuff for this
 
 import time
 import requests
@@ -36,6 +37,7 @@ class JellyfinTracker(tracker.TrackerBase):
         self.host_port = self.config['jellyfin_host']+":"+self.config['jellyfin_port']
         self.api_key = self.config['jellyfin_api_key']
         self.username = self.config['jellyfin_user']
+
         self.status_log = [None, None]
 
         super().__init__(messenger, tracker_list, config, watch_dirs, redirections)

--- a/trackma/tracker/jellyfin.py
+++ b/trackma/tracker/jellyfin.py
@@ -17,7 +17,6 @@
 import time
 import requests
 
-import trackma.utils as utils
 from trackma.tracker import tracker
 
 NOT_RUNNING = 0
@@ -38,73 +37,45 @@ class JellyfinTracker(tracker.TrackerBase):
         self.api_key = self.config['jellyfin_api_key']
         self.username = self.config['jellyfin_user']
         self.status_log = [None, None]
+
         super().__init__(messenger, tracker_list, config, watch_dirs, redirections)
-
-    def get_jellyfin_status(self, session_state):
-        # returns the plex status of the first active session
-        #try:
-        active = session_state
-
-        if active:
-            return ACTIVE
-        else:
-            return IDLE
-        #except urllib.request.URLError as e:
-        #    if e.code == 401:
-        #        return CLAIMED
-        #    else:
-        #        return NOT_RUNNING
-
-    def playing_file(self, session_info):
-        # returns the filename of the currently playing file
-        if self.get_jellyfin_status(session_info[0]) == IDLE:
-            return None
-
-        if not session_info[1]:
-            state = PLAYING
-        else:
-            state = PAUSED
-
-        name = session_info[2]
-
-        return (name, state)
 
     def observe(self, config, watch_dirs):
         self.msg.info(self.name, "Using Jellyfin.")
-        session_info = self._get_sessions_info()
 
         while self.active:
             session_info = self._get_sessions_info()
-            self.status_log.append(self.get_jellyfin_status(session_info[0]))
+            self.status_log.append(session_info['status'])
 
             if self.status_log[-1] == ACTIVE or self.status_log[-1] == IDLE:
                 if self.status_log[-1] == IDLE and self.status_log[-2] == NOT_RUNNING:
                     self.msg.info(self.name, "Reconnected to Jellyfin.")
                     self.wait_s = config['tracker_update_wait_s']
+
                 try:
-                    player = self.playing_file(session_info)
-                    (state, show_tuple) = self._get_playing_show(player[0])
-                            
-                    self.view_offset = int(session_info[3])
+                    (state, show_tuple) = self._get_playing_show(session_info['file_name'])
+
+                    self.view_offset = int(session_info['view_offset'])
 
                     self.update_show_if_needed(state, show_tuple)
 
-                    if player[1] == PAUSED:
+                    if session_info['state'] == PAUSED:
                         self.pause_timer()
-                    elif player[1] == PLAYING:
+                    elif session_info['state'] == PLAYING:
                         self.resume_timer()
 
-                except:
+                except (IndexError,TypeError):
                     if self.status_log[-1] == IDLE:
                         self.last_filename = None
                         self.update_show_if_needed(0, None)
                     else:
                         pass
+
             elif self.status_log[-1] == CLAIMED and self.status_log[-2] == CLAIMED:
                 self.msg.warn(
-                    self.name, "Claimed Plex Media Server, login in the settings and restart trackma.")
+                    self.name, "Claimed Jellyfin, login in the settings and restart trackma.")
             elif self.status_log[-1] == NOT_RUNNING and self.status_log[-2] == NOT_RUNNING:
-                self.msg.warn(self.name, "Plex Media Server is not running.")
+                self.msg.warn(self.name, "Jellyfin is not running.")
 
             del self.status_log[0]
 
@@ -112,22 +83,35 @@ class JellyfinTracker(tracker.TrackerBase):
             time.sleep(config['tracker_interval'])
 
     def _get_sessions_info(self):
-        # Get the required info from the /status/sessions url
         session_url = "http://"+self.host_port+"/Sessions?api_key={}".format(self.api_key)
-        response = requests.get(session_url).json()
-        for session in response:
+
+        info = {
+            "status": NOT_RUNNING,
+            "state": PAUSED,
+            "file_name": None,
+            "view_offset": None
+        }
+
+        try:
+            response = requests.get(session_url)
+            response_json = response.json()
+        except requests.exceptions.ConnectionError:
+            return info
+
+        for session in response_json:
             if not 'UserName' in session:
                 continue
             if session['UserName'] != self.username:
                 continue
 
-            if not 'NowPlayingItem' in session:
-                return (False, None, None, None)
+            if 'NowPlayingItem' in session:
+                current_session = session['NowPlayingItem']
+                return {
+                    "status": ACTIVE,
+                    "state": PAUSED if session['PlayState']['IsPaused'] else PLAYING,
+                    "file_name": current_session['Name'],
+                    "view_offset": int(session['PlayState']['PositionTicks']/10000)
+                }
 
-            current_session = session['NowPlayingItem']
-            return (
-                True,
-                session['PlayState']['IsPaused'],
-                current_session['Name'],
-                int(session['PlayState']['PositionTicks']/10000)
-            )
+        info["status"] = IDLE
+        return info

--- a/trackma/tracker/jellyfin.py
+++ b/trackma/tracker/jellyfin.py
@@ -1,0 +1,133 @@
+# This file is part of Trackma.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import time
+import requests
+
+import trackma.utils as utils
+from trackma.tracker import tracker
+
+NOT_RUNNING = 0
+ACTIVE = 1
+CLAIMED = 2
+PLAYING = 3
+PAUSED = 4
+IDLE = 5
+
+
+class JellyfinTracker(tracker.TrackerBase):
+    name = 'Tracker (Jellyfin)'
+
+    def __init__(self, messenger, tracker_list, config, watch_dirs, redirections=None):
+        self.config = config
+
+        self.host_port = self.config['jellyfin_host']+":"+self.config['jellyfin_port']
+        self.api_key = self.config['jellyfin_api_key']
+        self.username = self.config['jellyfin_user']
+        self.status_log = [None, None]
+        super().__init__(messenger, tracker_list, config, watch_dirs, redirections)
+
+    def get_jellyfin_status(self, session_state):
+        # returns the plex status of the first active session
+        #try:
+        active = session_state
+
+        if active:
+            return ACTIVE
+        else:
+            return IDLE
+        #except urllib.request.URLError as e:
+        #    if e.code == 401:
+        #        return CLAIMED
+        #    else:
+        #        return NOT_RUNNING
+
+    def playing_file(self, session_info):
+        # returns the filename of the currently playing file
+        if self.get_jellyfin_status(session_info[0]) == IDLE:
+            return None
+
+        if not session_info[1]:
+            state = PLAYING
+        else:
+            state = PAUSED
+
+        name = session_info[2]
+
+        return (name, state)
+
+    def observe(self, config, watch_dirs):
+        self.msg.info(self.name, "Using Jellyfin.")
+        session_info = self._get_sessions_info()
+
+        while self.active:
+            session_info = self._get_sessions_info()
+            self.status_log.append(self.get_jellyfin_status(session_info[0]))
+
+            if self.status_log[-1] == ACTIVE or self.status_log[-1] == IDLE:
+                if self.status_log[-1] == IDLE and self.status_log[-2] == NOT_RUNNING:
+                    self.msg.info(self.name, "Reconnected to Jellyfin.")
+                    self.wait_s = config['tracker_update_wait_s']
+                try:
+                    player = self.playing_file(session_info)
+                    (state, show_tuple) = self._get_playing_show(player[0])
+                            
+                    self.view_offset = int(session_info[3])
+
+                    self.update_show_if_needed(state, show_tuple)
+
+                    if player[1] == PAUSED:
+                        self.pause_timer()
+                    elif player[1] == PLAYING:
+                        self.resume_timer()
+
+                except:
+                    if self.status_log[-1] == IDLE:
+                        self.last_filename = None
+                        self.update_show_if_needed(0, None)
+                    else:
+                        pass
+            elif self.status_log[-1] == CLAIMED and self.status_log[-2] == CLAIMED:
+                self.msg.warn(
+                    self.name, "Claimed Plex Media Server, login in the settings and restart trackma.")
+            elif self.status_log[-1] == NOT_RUNNING and self.status_log[-2] == NOT_RUNNING:
+                self.msg.warn(self.name, "Plex Media Server is not running.")
+
+            del self.status_log[0]
+
+            # Wait for the interval before running check again
+            time.sleep(config['tracker_interval'])
+
+    def _get_sessions_info(self):
+        # Get the required info from the /status/sessions url
+        session_url = "http://"+self.host_port+"/Sessions?api_key={}".format(self.api_key)
+        response = requests.get(session_url).json()
+        for session in response:
+            if not 'UserName' in session:
+                continue
+            if session['UserName'] != self.username:
+                continue
+
+            if not 'NowPlayingItem' in session:
+                return (False, None, None, None)
+
+            current_session = session['NowPlayingItem']
+            return (
+                True,
+                session['PlayState']['IsPaused'],
+                current_session['Name'],
+                int(session['PlayState']['PositionTicks']/10000)
+            )

--- a/trackma/tracker/plex.py
+++ b/trackma/tracker/plex.py
@@ -110,6 +110,7 @@ class PlexTracker(tracker.TrackerBase):
 
                     if self.token:
                         if self.config['plex_user'] == xuser:
+                            self.view_offset = int(self._get_sessions_info("Video", "viewOffset"))
                             self.update_show_if_needed(state, show_tuple)
 
                             if player[1] == PAUSED:

--- a/trackma/tracker/tracker.py
+++ b/trackma/tracker/tracker.py
@@ -64,6 +64,8 @@ class TrackerBase(object):
         self.timer_paused = None
         self.timer_offset = 0
 
+        self.view_offset = None
+
         tracker_args = (config, watch_dirs)
         tracker_t = threading.Thread(target=self.observe, args=tracker_args)
         tracker_t.daemon = True
@@ -95,6 +97,7 @@ class TrackerBase(object):
         return {
             'state': self.last_state,
             'timer': self.timer,
+            'viewOffset': self.view_offset,
             'paused': bool(self.timer_paused),
             'show': self.last_show_tuple,
             'filename': self.last_filename,

--- a/trackma/ui/gtk/data/settingswindow.ui
+++ b/trackma/ui/gtk/data/settingswindow.ui
@@ -16,6 +16,13 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustment_jellyfin_port">
+    <property name="lower">-1</property>
+    <property name="upper">100000</property>
+    <property name="value">32400</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustment_kodi_port">
     <property name="lower">-1</property>
     <property name="upper">100000</property>
@@ -559,6 +566,141 @@
                             <property name="expand">False</property>
                             <property name="fill">True</property>
                             <property name="position">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">9</property>
+                        <child>
+                          <object class="GtkRadioButton" id="radio_tracker_jellyfin">
+                            <property name="label" translatable="yes">Jellyfin</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">radio_tracker_local</property>
+                            <signal name="toggled" handler="_set_tracker_radio_buttons" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkGrid">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="row_spacing">9</property>
+                            <property name="column_spacing">9</property>
+                            <property name="column_homogeneous">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Port</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Host</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="entry_jellyfin_host">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="spin_jellyfin_port">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="halign">end</property>
+                                <property name="text" translatable="yes">8096</property>
+                                <property name="adjustment">adjustment_jellyfin_port</property>
+                                <property name="value">8096</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Password</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Username</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="entry_jellyfin_username">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="entry_jellyfin_apikey">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">3</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
                           </packing>
                         </child>
                       </object>

--- a/trackma/ui/gtk/settingswindow.py
+++ b/trackma/ui/gtk/settingswindow.py
@@ -66,6 +66,12 @@ class SettingsWindow(Gtk.Window):
     checkbox_plex_obey_wait = GtkTemplate.Child()
     spin_tracker_update_wait = GtkTemplate.Child()
 
+    radio_tracker_jellyfin = GtkTemplate.Child()
+    entry_jellyfin_host = GtkTemplate.Child()
+    spin_jellyfin_port = GtkTemplate.Child()
+    entry_jellyfin_username = GtkTemplate.Child()
+    entry_jellyfin_apikey = GtkTemplate.Child()
+
     checkbox_tracker_update_close = GtkTemplate.Child()
     checkbox_tracker_update_prompt = GtkTemplate.Child()
     checkbox_tracker_not_found_prompt = GtkTemplate.Child()
@@ -159,6 +165,8 @@ class SettingsWindow(Gtk.Window):
             self.radio_tracker_mpris.set_active(True)
         elif self.engine.get_config('tracker_type') == 'plex':
             self.radio_tracker_plex.set_active(True)
+        elif self.engine.get_config('tracker_type') == 'jellyfin':
+            self.radio_tracker_jellyfin.set_active(True)
 
         self.entry_player_process.set_text(
             self.engine.get_config('tracker_process'))
@@ -179,6 +187,11 @@ class SettingsWindow(Gtk.Window):
             self.engine.get_config('plex_passwd'))
         self.checkbox_plex_obey_wait.set_active(
             self.engine.get_config('plex_obey_update_wait_s'))
+
+        self.entry_jellyfin_host.set_text(self.engine.get_config('jellyfin_host'))
+        self.spin_jellyfin_port.set_value(int(self.engine.get_config('jellyfin_port')))
+        self.entry_jellyfin_username.set_text(self.engine.get_config('jellyfin_user'))
+        self.entry_jellyfin_apikey.set_text(self.engine.get_config('jellyfin_api_key'))
 
         self.spin_tracker_update_wait.set_value(
             self.engine.get_config('tracker_update_wait_s'))
@@ -274,12 +287,14 @@ class SettingsWindow(Gtk.Window):
         self.radio_tracker_local.set_sensitive(state)
         self.radio_tracker_mpris.set_sensitive(state)
         self.radio_tracker_plex.set_sensitive(state)
+        self.radio_tracker_jellyfin.set_sensitive(state)
 
         if state:
             self._set_tracker_radio_buttons()
         else:
             self._enable_local(state)
             self._enable_plex(state)
+            self._enable_jellyfin(state)
 
         self.checkbox_tracker_update_close.set_sensitive(state)
         self.checkbox_tracker_update_prompt.set_sensitive(state)
@@ -290,9 +305,11 @@ class SettingsWindow(Gtk.Window):
         if self.radio_tracker_local.get_active() or self.radio_tracker_mpris.get_active():
             self._enable_local(True)
             self._enable_plex(False)
+            self._enable_jellyfin(False)
         else:
             self._enable_local(False)
             self._enable_plex(True)
+            self._enable_jellyfin(True)
 
     def _enable_local(self, enable):
         self.entry_player_process.set_sensitive(enable)
@@ -307,6 +324,12 @@ class SettingsWindow(Gtk.Window):
         self.entry_plex_username.set_sensitive(enable)
         self.entry_plex_password.set_sensitive(enable)
         self.checkbox_plex_obey_wait.set_sensitive(enable)
+
+    def _enable_jellyfin(self, enable):
+        self.entry_jellyfin_host.set_sensitive(enable)
+        self.spin_jellyfin_port.set_sensitive(enable)
+        self.entry_jellyfin_username.set_sensitive(enable)
+        self.entry_jellyfin_apikey.set_sensitive(enable)
 
     def _load_directories(self, paths):
         if isinstance(paths, str):
@@ -355,6 +378,13 @@ class SettingsWindow(Gtk.Window):
             'plex_user', self.entry_plex_username.get_text())
         self.engine.set_config(
             'plex_passwd', self.entry_plex_password.get_text())
+        self.engine.set_config('jellyfin_host', self.entry_jellyfin_host.get_text())
+        self.engine.set_config('jellyfin_port', str(
+            int(self.spin_jellyfin_port.get_value())))
+        self.engine.set_config(
+            'jellyfin_user', self.entry_jellyfin_username.get_text())
+        self.engine.set_config(
+            'jellyfin_api_key', self.entry_jellyfin_apikey.get_text())
         self.engine.set_config(
             'tracker_enabled', self.switch_tracker.get_active())
         self.engine.set_config(
@@ -378,6 +408,8 @@ class SettingsWindow(Gtk.Window):
             self.engine.set_config('tracker_type', 'mpris')
         elif self.radio_tracker_plex.get_active():
             self.engine.set_config('tracker_type', 'plex')
+        elif self.radio_tracker_jellyfin.get_active():
+            self.engine.set_config('tracker_type', 'jellyfin')
 
         # Auto-retrieve
         if self.radiobutton_download_always.get_active():

--- a/trackma/ui/qt/settings.py
+++ b/trackma/ui/qt/settings.py
@@ -138,6 +138,30 @@ class SettingsDialog(QDialog):
 
         g_plex.setLayout(g_plex_layout)
 
+        # Group: Jellyfin settings
+        g_jellyfin = QGroupBox('Jellyfin')
+        g_jellyfin.setFlat(True)
+        self.jellyfin_host = QLineEdit()
+        self.jellyfin_port = QLineEdit()
+        self.jellyfin_user = QLineEdit()
+        self.jellyfin_apikey = QLineEdit()
+
+        g_jellyfin_layout = QGridLayout()
+        g_jellyfin_layout.addWidget(
+            QLabel('Host and Port'),                   0, 0, 1, 1)
+        g_jellyfin_layout.addWidget(self.jellyfin_host,
+                                0, 1, 1, 1)
+        g_jellyfin_layout.addWidget(self.jellyfin_port,
+                                0, 2, 1, 2)
+        g_jellyfin_layout.addWidget(
+            QLabel('API and User'),                   1, 0, 1, 1)
+        g_jellyfin_layout.addWidget(self.jellyfin_apikey,
+                                1, 1, 1, 1)
+        g_jellyfin_layout.addWidget(self.jellyfin_user,
+                                1, 2, 1, 2)
+
+        g_jellyfin.setLayout(g_jellyfin_layout)
+
         # Group: Kodi settings
         g_kodi = QGroupBox('Kodi')
         g_kodi.setFlat(True)
@@ -220,6 +244,7 @@ class SettingsDialog(QDialog):
         # Media form
         page_media_layout.addWidget(g_media)
         page_media_layout.addWidget(g_plex)
+        page_media_layout.addWidget(g_jellyfin)
         page_media_layout.addWidget(g_kodi)
         page_media_layout.addWidget(g_playnext)
         page_media.setLayout(page_media_layout)
@@ -488,6 +513,11 @@ class SettingsDialog(QDialog):
         self.plex_user.setText(engine.get_config('plex_user'))
         self.plex_passw.setText(engine.get_config('plex_passwd'))
 
+        self.jellyfin_host.setText(engine.get_config('jellyfin_host'))
+        self.jellyfin_port.setText(engine.get_config('jellyfin_port'))
+        self.jellyfin_user.setText(engine.get_config('jellyfin_user'))
+        self.jellyfin_apikey.setText(engine.get_config('jellyfin_api_key'))
+
         self.kodi_host.setText(engine.get_config('kodi_host'))
         self.kodi_port.setText(engine.get_config('kodi_port'))
         self.kodi_obey_wait.setChecked(
@@ -590,6 +620,11 @@ class SettingsDialog(QDialog):
         engine.set_config('plex_user',         self.plex_user.text())
         engine.set_config('plex_passwd',       self.plex_passw.text())
 
+        engine.set_config('jellyfin_host',         self.jellyfin_host.text())
+        engine.set_config('jellyfin_port',         self.jellyfin_port.text())
+        engine.set_config('jellyfin_user',         self.jellyfin_user.text())
+        engine.set_config('jellyfin_apikey',       self.jellyfin_apikey.text())
+
         engine.set_config('kodi_host',         self.kodi_host.text())
         engine.set_config('kodi_port',         self.kodi_port.text())
         engine.set_config('kodi_obey_update_wait_s',
@@ -673,25 +708,40 @@ class SettingsDialog(QDialog):
         self.plex_passw.setEnabled(state)
         self.plex_obey_wait.setEnabled(state)
 
+    def switch_jellyfin_state(self, state):
+        self.jellyfin_host.setEnabled(state)
+        self.jellyfin_port.setEnabled(state)
+        self.jellyfin_user.setEnabled(state)
+        self.jellyfin_apikey.setEnabled(state)
+
     def tracker_type_change(self, checked):
         if self.tracker_enabled.isChecked():
             self.tracker_interval.setEnabled(True)
             self.tracker_update_wait.setEnabled(True)
             self.tracker_type.setEnabled(True)
             if self.tracker_type.itemData(self.tracker_type.currentIndex()) == 'plex':
+                self.switch_jellyfin_state(False)
                 self.switch_plex_state(True)
                 self.switch_kodi_state(False)
                 self.tracker_process.setEnabled(False)
+            elif self.tracker_type.itemData(self.tracker_type.currentIndex()) == 'jellyfin':
+                self.switch_jellyfin_state(True)
+                self.switch_kodi_state(False)
+                self.switch_plex_state(False)
+                self.tracker_process.setEnabled(False)
             elif self.tracker_type.itemData(self.tracker_type.currentIndex()) == 'kodi':
+                self.switch_jellyfin_state(False)
                 self.switch_kodi_state(True)
                 self.switch_plex_state(False)
                 self.tracker_process.setEnabled(False)
             else:
                 self.tracker_process.setEnabled(True)
+                self.switch_jellyfin_state(False)
                 self.switch_plex_state(False)
                 self.switch_kodi_state(False)
         else:
             self.tracker_type.setEnabled(False)
+            self.switch_jellyfin_state(False)
             self.switch_plex_state(False)
             self.switch_kodi_state(False)
 

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -91,6 +91,7 @@ available_trackers = [
     ('polling', 'Polling (lsof)'),
     ('mpris', 'MPRIS'),
     ('plex', 'Plex Media Server'),
+    ('jellyfin', 'Jellyfin'),
     ('kodi', 'Kodi'),
     ('win32', 'Win32'),
 ]
@@ -450,6 +451,10 @@ config_defaults = {
     'plex_user': '',
     'plex_passwd': '',
     'plex_uuid': str(uuid.uuid1()),
+    'jellyfin_host': "localhost",
+    'jellyfin_port': "8096",
+    'jellyfin_api_key': '',
+    'jellyfin_user': '',
     'kodi_host': "localhost",
     'kodi_port': "8080",
     'kodi_obey_update_wait_s': False,


### PR DESCRIPTION
Wanted trackma to keep track of my Jellyfin instance so I decided to fully implement it into the source code. I also added a view offset setting for the session info, I implemented this for one of my discord hooks to display where I am in the show. 

Some things to note for documentation:
- The API key in the config file is found in Jellyfin under Dashboard -> API Keys, where the user needs to generate this key and plug it into the config file. It seems that this can only be generated under an admin user
- The username in the config file is what user the user wants to track