### PR TITLE
Update tracker after altname changes

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -967,6 +967,8 @@ class Engine:
                 self.data_handler.altname_set(showid, newname)
                 self.msg.info(
                     self.name, 'Changed alternate name to %s.' % newname)
+            # Update the tracker with the new altname
+            self._update_tracker()
         else:
             return self.data_handler.altname_get(showid)
 


### PR DESCRIPTION
This PR will close #540. If this is merged, trackma will follow the expected behavior instead of the current one.