### PR TITLE
Tweak show recognition code and add tests

### DIFF
--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -88,7 +88,7 @@ def test_dubsub():
         extension="mkv",
         resolution="1080p",
         audioType=["AAC"],
-        releaseSource=["WEB"],
+        releaseSource=["Web-DL"],
     )
 
 
@@ -115,4 +115,20 @@ def test_name_with_year_and_extra_brackets():
         subberTag="Erai-raws",
         extension="mkv",
         resolution="1080p",
+    )
+
+
+def test_eac3():
+    aie = AnimeInfoExtractor("[PAS] Houseki no Kuni - 05 [WEB 720p E-AC-3] [F671AE53].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Houseki no Kuni",
+        episodeStart=5,
+        subberTag="PAS",
+        extension="mkv",
+        resolution="720p",
+        audioType=["E-AC-3"],
+        releaseSource=["WEB"],
+        hash="F671AE53",
     )

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -61,7 +61,7 @@ def test_compound_subber_tag_and_wierd_epnum():
     )
 
 
-def test_late_subber_tag_with_hash():
+def test_late_subber_tag_with_hash_and_commas():
     aie = AnimeInfoExtractor("Chio-chan no Tsuugakuro - 04 [HorribleSubs] [www, 720p, AAC] [5D4D1205].mkv")
     pprint(vars(aie))
     _assert_aie(
@@ -93,22 +93,19 @@ def test_dubsub():
 
 
 def test_name_with_year():
-    aie = AnimeInfoExtractor("Bungou Stray Dogs (2019) - 06 [HorribleSubs] [www, 720p, AAC] [496D45BB].mkv")
+    aie = AnimeInfoExtractor("[TestTag] Bungou Stray Dogs (2019) - 06 [496D45BB].mkv")
     pprint(vars(aie))
     _assert_aie(
         aie,
         name="Bungou Stray Dogs (2019)",
         episodeStart=6,
-        subberTag="HorribleSubs",
+        subberTag="TestTag",
         extension="mkv",
-        resolution="720p",
-        audioType=["AAC"],
-        releaseSource=["www"],
         hash="496D45BB",
     )
 
 
-def test_name_with_year_2():
+def test_name_with_year_and_extra_brackets():
     aie = AnimeInfoExtractor("[Erai-raws] Fairy Tail (2018) - 45 [1080p][Multiple Subtitle].mkv")
     pprint(vars(aie))
     _assert_aie(

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -19,6 +19,7 @@ DEFAULTS = {
     'version': 1,
     'name': '',
     'pv': -1,
+    'season': None,
 }
 
 
@@ -146,4 +147,18 @@ def test_with_episode_title():
         resolution="720p",
         releaseSource=["BD"],
         hash="FF757616",
+    )
+
+
+def test_name_sXXeXX_and_sdtv():
+    aie = AnimeInfoExtractor("Clannad - S02E01 - A Farewell to the End of Summer SDTV.mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Clannad 2",
+        season=2,
+        episodeStart=1,
+        extension="mkv",
+        resolution="SD",
+        releaseSource=["TV"],
     )

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -23,21 +23,23 @@ DEFAULTS = {
 }
 
 
-def _assert_aie(aie, **assertions):
+def _assert_aie(filename, **assertions):
     """Helper for asserting AnimeInfoExtractor results.
 
     Accepts a dict of assertions and asserts everything not provided as unchanged.
     """
+    aie = AnimeInfoExtractor(filename)
+    pprint(vars(aie))  # print defails for quicker debugging on failure
     for key, default in DEFAULTS.items():
         expected = assertions.get(key, default)
         assert getattr(aie, key) == expected
+    return aie
 
 
 def test_horriblesubs():
-    name = "[HorribleSubs] Nobunaga-sensei no Osanazuma - 04 [720p].mkv"
-    aie = AnimeInfoExtractor(name)
-    _assert_aie(
-        aie,
+    filename = "[HorribleSubs] Nobunaga-sensei no Osanazuma - 04 [720p].mkv"
+    aie = _assert_aie(
+        filename,
         name="Nobunaga-sensei no Osanazuma",
         episodeStart=4,
         subberTag="HorribleSubs",
@@ -45,16 +47,14 @@ def test_horriblesubs():
         resolution="720p",
     )
     # check these only once
-    assert aie.originalFilename == name
+    assert aie.originalFilename == filename
     assert aie.getName() == "Nobunaga-sensei no Osanazuma"
     assert aie.getEpisode() == 4
 
 
 def test_compound_subber_tag_and_wierd_epnum():
-    aie = AnimeInfoExtractor("[VCB-Studio+Commie] Sword Art Online II [03].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "[VCB-Studio+Commie] Sword Art Online II [03].mkv",
         name="Sword Art Online II",
         episodeStart=3,
         subberTag="VCB-Studio+Commie",
@@ -63,10 +63,8 @@ def test_compound_subber_tag_and_wierd_epnum():
 
 
 def test_late_subber_tag_with_hash_and_commas():
-    aie = AnimeInfoExtractor("Chio-chan no Tsuugakuro - 04 [HorribleSubs] [www, 720p, AAC] [5D4D1205].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "Chio-chan no Tsuugakuro - 04 [HorribleSubs] [www, 720p, AAC] [5D4D1205].mkv",
         name="Chio-chan no Tsuugakuro",
         episodeStart=4,
         subberTag="HorribleSubs",
@@ -79,10 +77,8 @@ def test_late_subber_tag_with_hash_and_commas():
 
 
 def test_dubsub():
-    aie = AnimeInfoExtractor("Arifureta E01v1 [1080p+][AAC][JapDub][GerSub][Web-DL].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "Arifureta E01v1 [1080p+][AAC][JapDub][GerSub][Web-DL].mkv",
         name="Arifureta",
         episodeStart=1,
         subberTag="JapDub",
@@ -94,10 +90,8 @@ def test_dubsub():
 
 
 def test_name_with_year():
-    aie = AnimeInfoExtractor("[TestTag] Bungou Stray Dogs (2019) - 06 [496D45BB].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "[TestTag] Bungou Stray Dogs (2019) - 06 [496D45BB].mkv",
         name="Bungou Stray Dogs (2019)",
         episodeStart=6,
         subberTag="TestTag",
@@ -107,10 +101,8 @@ def test_name_with_year():
 
 
 def test_name_with_year_and_extra_brackets():
-    aie = AnimeInfoExtractor("[Erai-raws] Fairy Tail (2018) - 45 [1080p][Multiple Subtitle].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "[Erai-raws] Fairy Tail (2018) - 45 [1080p][Multiple Subtitle].mkv",
         name="Fairy Tail (2018)",
         episodeStart=45,
         subberTag="Erai-raws",
@@ -120,10 +112,8 @@ def test_name_with_year_and_extra_brackets():
 
 
 def test_eac3():
-    aie = AnimeInfoExtractor("[PAS] Houseki no Kuni - 05 [WEB 720p E-AC-3] [F671AE53].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "[PAS] Houseki no Kuni - 05 [WEB 720p E-AC-3] [F671AE53].mkv",
         name="Houseki no Kuni",
         episodeStart=5,
         subberTag="PAS",
@@ -136,10 +126,8 @@ def test_eac3():
 
 
 def test_with_number_in_episode_title():
-    aie = AnimeInfoExtractor("[Opportunity] The Tatami Galaxy 10 - The 4.5-Tatami Idealogue [BD 720p] [FF757616].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "[Opportunity] The Tatami Galaxy 10 - The 4.5-Tatami Idealogue [BD 720p] [FF757616].mkv",
         name="The Tatami Galaxy",
         episodeStart=10,
         subberTag="Opportunity",
@@ -151,10 +139,8 @@ def test_with_number_in_episode_title():
 
 
 def test_with_standalone_number_in_episode_title():
-    aie = AnimeInfoExtractor("Monogatari - S02E01 - Karen Bee - Part 2.mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "Monogatari - S02E01 - Karen Bee - Part 2.mkv",
         name="Monogatari 2",
         season=2,
         episodeStart=1,
@@ -163,10 +149,8 @@ def test_with_standalone_number_in_episode_title():
 
 
 def test_sXXeXX_and_sdtv():
-    aie = AnimeInfoExtractor("Clannad - S02E01 - A Farewell to the End of Summer SDTV.mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "Clannad - S02E01 - A Farewell to the End of Summer SDTV.mkv",
         name="Clannad 2",
         season=2,
         episodeStart=1,
@@ -177,10 +161,8 @@ def test_sXXeXX_and_sdtv():
 
 
 def test_sXXeXX_and_trailing_hyphen():
-    aie = AnimeInfoExtractor("ReZERO -Starting Life in Another World- S02E06 [1080p][E-AC3].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "ReZERO -Starting Life in Another World- S02E06 [1080p][E-AC3].mkv",
         name="ReZERO -Starting Life in Another World- 2",
         season=2,
         episodeStart=6,
@@ -191,10 +173,8 @@ def test_sXXeXX_and_trailing_hyphen():
 
 
 def test_with_brackets():
-    aie = AnimeInfoExtractor("[HorribleSubs] Nakanohito Genome [Jikkyouchuu] - 01 [1080p].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "[HorribleSubs] Nakanohito Genome [Jikkyouchuu] - 01 [1080p].mkv",
         name="Nakanohito Genome",  # ' [Jikkyouchuu]' is stripped currently
         episodeStart=1,
         subberTag="HorribleSubs",
@@ -204,10 +184,8 @@ def test_with_brackets():
 
 
 def test_with_dots():
-    aie = AnimeInfoExtractor("Kill.la.Kill.S01E01.1080p-Hi10p.BluRay.FLAC2.0.x264-CTR.[98AA9B1C].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "Kill.la.Kill.S01E01.1080p-Hi10p.BluRay.FLAC2.0.x264-CTR.[98AA9B1C].mkv",
         name="Kill la Kill",
         season=1,
         episodeStart=1,
@@ -221,10 +199,8 @@ def test_with_dots():
 
 
 def test_unusual_subber():
-    aie = AnimeInfoExtractor("[-__-'] Girls und Panzer OVA 6 [BD 1080p FLAC] [B13C83A0].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "[-__-'] Girls und Panzer OVA 6 [BD 1080p FLAC] [B13C83A0].mkv",
         name="Girls und Panzer OVA",
         episodeStart=6,
         subberTag="-__-'",
@@ -237,10 +213,8 @@ def test_unusual_subber():
 
 
 def test_unusual_subber_and_no_epnum():
-    aie = AnimeInfoExtractor("[-__-'] Girls und Panzer OVA Anzio-sen [BD 1080p FLAC] [231FDA45].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "[-__-'] Girls und Panzer OVA Anzio-sen [BD 1080p FLAC] [231FDA45].mkv",
         name="Girls und Panzer OVA Anzio-sen",
         subberTag="-__-'",
         extension="mkv",
@@ -252,10 +226,8 @@ def test_unusual_subber_and_no_epnum():
 
 
 def test_nothing_in_particular():
-    aie = AnimeInfoExtractor("[Underwater-FFF] Saki Zenkoku-hen - The Nationals - 01 [BD][1080p-FLAC][81722FD7].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "[Underwater-FFF] Saki Zenkoku-hen - The Nationals - 01 [BD][1080p-FLAC][81722FD7].mkv",
         name="Saki Zenkoku-hen - The Nationals",
         episodeStart=1,
         subberTag="Underwater-FFF",
@@ -268,10 +240,8 @@ def test_nothing_in_particular():
 
 
 def test_hi444pp_profile():
-    aie = AnimeInfoExtractor("[Erai-raws] Goblin Slayer - Goblin's Crown [BD][1080p YUV444P10][FLAC][Multiple Subtitle].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "[Erai-raws] Goblin Slayer - Goblin's Crown [BD][1080p YUV444P10][FLAC][Multiple Subtitle].mkv",
         name="Goblin Slayer - Goblin's Crown",
         subberTag="Erai-raws",
         extension="mkv",
@@ -283,10 +253,8 @@ def test_hi444pp_profile():
 
 
 def test_jpbd_lpcm():
-    aie = AnimeInfoExtractor("[Koten_Gars] Kiddy Grade - Movie I [JP.BD][Hi10][1080p][LPCM] [2FAAB41B].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "[Koten_Gars] Kiddy Grade - Movie I [JP.BD][Hi10][1080p][LPCM] [2FAAB41B].mkv",
         name="Kiddy Grade - Movie I",
         subberTag="Koten_Gars",
         extension="mkv",
@@ -299,10 +267,8 @@ def test_jpbd_lpcm():
 
 
 def test_underscores():
-    aie = AnimeInfoExtractor("[No]Touhou_Gensou_Mangekyou_-_01_(Hi10P)[26D7A2B3].mkv")
-    pprint(vars(aie))
     _assert_aie(
-        aie,
+        "[No]Touhou_Gensou_Mangekyou_-_01_(Hi10P)[26D7A2B3].mkv",
         name="Touhou Gensou Mangekyou",
         episodeStart=1,
         subberTag="No",

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -284,3 +284,17 @@ def test_jpbd_lpcm():
         videoType=["H264", "Hi10P"],
         hash="2FAAB41B"
     )
+
+
+def test_underscores():
+    aie = AnimeInfoExtractor("[No]Touhou_Gensou_Mangekyou_-_01_(Hi10P)[26D7A2B3].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Touhou Gensou Mangekyou",
+        episodeStart=1,
+        subberTag="No",
+        extension="mkv",
+        videoType=["H264", "Hi10P"],
+        hash="26D7A2B3"
+    )

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -135,7 +135,7 @@ def test_eac3():
     )
 
 
-def test_with_episode_title():
+def test_with_number_in_episode_title():
     aie = AnimeInfoExtractor("[Opportunity] The Tatami Galaxy 10 - The 4.5-Tatami Idealogue [BD 720p] [FF757616].mkv")
     pprint(vars(aie))
     _assert_aie(
@@ -147,6 +147,18 @@ def test_with_episode_title():
         resolution="720p",
         releaseSource=["BD"],
         hash="FF757616",
+    )
+
+
+def test_with_standalone_number_in_episode_title():
+    aie = AnimeInfoExtractor("Monogatari - S02E01 - Karen Bee - Part 2.mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Monogatari 2",
+        season=2,
+        episodeStart=1,
+        extension="mkv",
     )
 
 

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -276,3 +276,12 @@ def test_underscores():
         videoType=["H264", "Hi10P"],
         hash="26D7A2B3"
     )
+
+
+def test_literal_ep():
+    _assert_aie(
+        "Uzaki-chan wa Asobitai! Ep 2.mkv",
+        name="Uzaki-chan wa Asobitai!",
+        episodeStart=2,
+        extension="mkv",
+    )

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -176,3 +176,20 @@ def test_name_sXXeXX_and_trailing_hyphen():
         resolution="1080p",
         audioType=["E-AC3"],
     )
+
+
+def test_with_dots():
+    aie = AnimeInfoExtractor("Kill.la.Kill.S01E01.1080p-Hi10p.BluRay.FLAC2.0.x264-CTR.[98AA9B1C].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Kill la Kill",
+        season=1,
+        episodeStart=1,
+        extension="mkv",
+        resolution="1080p",
+        # releaseSource="BluRay",
+        # audioType=["FLAC"],
+        videoType=["H264", "Hi10P"],
+        hash="98AA9B1C",
+    )

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -73,6 +73,7 @@ def test_late_subber_tag_with_hash():
         resolution="720p",
         audioType=["AAC"],
         hash="5D4D1205",
+        releaseSource=["www"],
     )
 
 
@@ -87,4 +88,5 @@ def test_dubsub():
         extension="mkv",
         resolution="1080p",
         audioType=["AAC"],
+        releaseSource=["WEB"],
     )

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -132,3 +132,18 @@ def test_eac3():
         releaseSource=["WEB"],
         hash="F671AE53",
     )
+
+
+def test_with_episode_title():
+    aie = AnimeInfoExtractor("[Opportunity] The Tatami Galaxy 10 - The 4.5-Tatami Idealogue [BD 720p] [FF757616].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="The Tatami Galaxy",
+        episodeStart=10,
+        subberTag="Opportunity",
+        extension="mkv",
+        resolution="720p",
+        releaseSource=["BD"],
+        hash="FF757616",
+    )

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -1,0 +1,90 @@
+from pprint import pprint
+
+# import pytest
+
+from trackma.extras import AnimeInfoExtractor
+
+DEFAULTS = {
+    'resolution': '',
+    'hash': '',
+    'subberTag': '',
+    'videoType': [],
+    'audioType': [],
+    'releaseSource': [],
+    'extension': '',
+    'episodeStart': None,
+    'episodeEnd': None,
+    'volumeStart': None,
+    'volumeEnd': None,
+    'version': 1,
+    'name': '',
+    'pv': -1,
+}
+
+
+def _assert_aie(aie, **assertions):
+    """Helper for asserting AnimeInfoExtractor results.
+
+    Accepts a dict of assertions and asserts everything not provided as unchanged.
+    """
+    for key, default in DEFAULTS.items():
+        expected = assertions.get(key, default)
+        assert getattr(aie, key) == expected
+
+
+def test_horriblesubs():
+    name = "[HorribleSubs] Nobunaga-sensei no Osanazuma - 04 [720p].mkv"
+    aie = AnimeInfoExtractor(name)
+    _assert_aie(
+        aie,
+        name="Nobunaga-sensei no Osanazuma",
+        episodeStart=4,
+        subberTag="HorribleSubs",
+        extension="mkv",
+        resolution="720p",
+    )
+    # check these only once
+    assert aie.originalFilename == name
+    assert aie.getName() == "Nobunaga-sensei no Osanazuma"
+    assert aie.getEpisode() == 4
+
+
+def test_compound_subber_tag_and_wierd_epnum():
+    aie = AnimeInfoExtractor("[VCB-Studio+Commie] Sword Art Online II [03].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Sword Art Online II",
+        episodeStart=3,
+        subberTag="VCB-Studio+Commie",
+        extension="mkv",
+    )
+
+
+def test_late_subber_tag_with_hash():
+    aie = AnimeInfoExtractor("Chio-chan no Tsuugakuro - 04 [HorribleSubs] [www, 720p, AAC] [5D4D1205].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Chio-chan no Tsuugakuro",
+        episodeStart=4,
+        subberTag="HorribleSubs",
+        extension="mkv",
+        resolution="720p",
+        audioType=["AAC"],
+        hash="5D4D1205",
+    )
+
+
+def test_dubsub():
+    aie = AnimeInfoExtractor("Arifureta E01v1 [1080p+][AAC][JapDub][GerSub][Web-DL].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Arifureta",
+        episodeStart=1,
+        subberTag="JapDub",
+        extension="mkv",
+        resolution="1080p",
+        audioType=["AAC"],
+    )

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -253,3 +253,18 @@ def test_nothing_in_particular():
         audioType=["FLAC"],
         hash="81722FD7",
     )
+
+
+def test_hi444pp_profile():
+    aie = AnimeInfoExtractor("[Erai-raws] Goblin Slayer - Goblin's Crown [BD][1080p YUV444P10][FLAC][Multiple Subtitle].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Goblin Slayer - Goblin's Crown",
+        subberTag="Erai-raws",
+        extension="mkv",
+        resolution="1080p",
+        releaseSource=["BD"],
+        audioType=["FLAC"],
+        videoType=["H264", "Hi444PP"],
+    )

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -162,3 +162,17 @@ def test_name_sXXeXX_and_sdtv():
         resolution="SD",
         releaseSource=["TV"],
     )
+
+
+def test_name_sXXeXX_and_trailing_hyphen():
+    aie = AnimeInfoExtractor("ReZERO -Starting Life in Another World- S02E06 [1080p][E-AC3].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="ReZERO -Starting Life in Another World- 2",
+        season=2,
+        episodeStart=6,
+        extension="mkv",
+        resolution="1080p",
+        audioType=["E-AC3"],
+    )

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -188,8 +188,24 @@ def test_with_dots():
         episodeStart=1,
         extension="mkv",
         resolution="1080p",
-        # releaseSource="BluRay",
+        # releaseSource=["BluRay"],
         # audioType=["FLAC"],
         videoType=["H264", "Hi10P"],
         hash="98AA9B1C",
+    )
+
+
+def test_unusual_subber():
+    aie = AnimeInfoExtractor("[-__-'] Girls und Panzer OVA 6 [BD 1080p FLAC] [B13C83A0].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Girls und Panzer OVA",
+        episodeStart=6,
+        subberTag="-__-'",
+        extension="mkv",
+        resolution="1080p",
+        releaseSource=["BD"],
+        audioType=["FLAC"],
+        hash="B13C83A0",
     )

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -90,3 +90,32 @@ def test_dubsub():
         audioType=["AAC"],
         releaseSource=["WEB"],
     )
+
+
+def test_name_with_year():
+    aie = AnimeInfoExtractor("Bungou Stray Dogs (2019) - 06 [HorribleSubs] [www, 720p, AAC] [496D45BB].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Bungou Stray Dogs (2019)",
+        episodeStart=6,
+        subberTag="HorribleSubs",
+        extension="mkv",
+        resolution="720p",
+        audioType=["AAC"],
+        releaseSource=["www"],
+        hash="496D45BB",
+    )
+
+
+def test_name_with_year_2():
+    aie = AnimeInfoExtractor("[Erai-raws] Fairy Tail (2018) - 45 [1080p][Multiple Subtitle].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Fairy Tail (2018)",
+        episodeStart=45,
+        subberTag="Erai-raws",
+        extension="mkv",
+        resolution="1080p",
+    )

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -268,3 +268,19 @@ def test_hi444pp_profile():
         audioType=["FLAC"],
         videoType=["H264", "Hi444PP"],
     )
+
+
+def test_jpbd_lpcm():
+    aie = AnimeInfoExtractor("[Koten_Gars] Kiddy Grade - Movie I [JP.BD][Hi10][1080p][LPCM] [2FAAB41B].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Kiddy Grade - Movie I",
+        subberTag="Koten_Gars",
+        extension="mkv",
+        resolution="1080p",
+        releaseSource=["BD"],
+        audioType=["LPCM"],
+        videoType=["H264", "Hi10P"],
+        hash="2FAAB41B"
+    )

--- a/tests/test_anime_info_extractor.py
+++ b/tests/test_anime_info_extractor.py
@@ -150,7 +150,7 @@ def test_with_episode_title():
     )
 
 
-def test_name_sXXeXX_and_sdtv():
+def test_sXXeXX_and_sdtv():
     aie = AnimeInfoExtractor("Clannad - S02E01 - A Farewell to the End of Summer SDTV.mkv")
     pprint(vars(aie))
     _assert_aie(
@@ -164,7 +164,7 @@ def test_name_sXXeXX_and_sdtv():
     )
 
 
-def test_name_sXXeXX_and_trailing_hyphen():
+def test_sXXeXX_and_trailing_hyphen():
     aie = AnimeInfoExtractor("ReZERO -Starting Life in Another World- S02E06 [1080p][E-AC3].mkv")
     pprint(vars(aie))
     _assert_aie(
@@ -175,6 +175,19 @@ def test_name_sXXeXX_and_trailing_hyphen():
         extension="mkv",
         resolution="1080p",
         audioType=["E-AC3"],
+    )
+
+
+def test_with_brackets():
+    aie = AnimeInfoExtractor("[HorribleSubs] Nakanohito Genome [Jikkyouchuu] - 01 [1080p].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Nakanohito Genome",  # ' [Jikkyouchuu]' is stripped currently
+        episodeStart=1,
+        subberTag="HorribleSubs",
+        extension="mkv",
+        resolution="1080p",
     )
 
 
@@ -208,4 +221,35 @@ def test_unusual_subber():
         releaseSource=["BD"],
         audioType=["FLAC"],
         hash="B13C83A0",
+    )
+
+
+def test_unusual_subber_and_no_epnum():
+    aie = AnimeInfoExtractor("[-__-'] Girls und Panzer OVA Anzio-sen [BD 1080p FLAC] [231FDA45].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Girls und Panzer OVA Anzio-sen",
+        subberTag="-__-'",
+        extension="mkv",
+        resolution="1080p",
+        releaseSource=["BD"],
+        audioType=["FLAC"],
+        hash="231FDA45",
+    )
+
+
+def test_nothing_in_particular():
+    aie = AnimeInfoExtractor("[Underwater-FFF] Saki Zenkoku-hen - The Nationals - 01 [BD][1080p-FLAC][81722FD7].mkv")
+    pprint(vars(aie))
+    _assert_aie(
+        aie,
+        name="Saki Zenkoku-hen - The Nationals",
+        episodeStart=1,
+        subberTag="Underwater-FFF",
+        extension="mkv",
+        resolution="1080p",
+        releaseSource=["BD"],
+        audioType=["FLAC"],
+        hash="81722FD7",
     )

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -853,8 +853,9 @@ class Engine:
 
                     show_id = show['id']
                 else:
-                    self.msg.debug(
-                        self.name, "Not a show, skipping: {}".format(fullpath))
+                    self.msg.debug(self.name,
+                                   "Unable to match '{}', skipping: {}"
+                                   .format(show_title, fullpath))
                     library_cache[filename] = None
             else:
                 self.msg.debug(

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -844,7 +844,7 @@ class Engine:
                             (show, show_ep_start), self.redirections, tracker_list)
                         show_ep_end = show_ep_start = show_ep
 
-                        self.msg.debug(self.name, "Redirected to {} {}".format(
+                        self.msg.debug(self.name, "Redirected to: {} {}".format(
                             show['title'], show_ep))
                         library_cache[filename] = (show['id'], show_ep)
                     else:

--- a/trackma/extras/AnimeInfoExtractor.py
+++ b/trackma/extras/AnimeInfoExtractor.py
@@ -128,22 +128,25 @@ class AnimeInfoExtractor():
 
     def __extractResolution(self, filename):
         # Match 3 or 4 chars followed by p, i, or x and 3 or 4 more chars, surrounded by any non-alphanumberic chars
-        m = re.search(
-            r'\b(\d{3,4}(?:p|i|x\d{3,4}))\b', filename)
+        m = re.search(r'\b(\d{3,4}(?:p|i|x\d{3,4}))\b', filename)
         if m:
             self.resolution = m.group(1)
-            filename = filename[:m.start(1)] + filename[m.end(1):]
-        else:
-            m = re.search(r'[\[\(\d](HD|SD)\b', filename)
-            if m:
-                self.resolution = m.group(1)
-                filename = filename[:m.start(1)] + filename[m.end(1):]
-            else:
-                m = re.search(r'(?:\d{1,3})(HD|SD)\b', filename)
-                if m:
-                    self.resolution = m.group(1)
-                    # Super special case for HD/SD imediately after episode
-                    filename = filename[:m.start(1)] + filename[m.end(1):]
+            return filename[:m.start(1)] + filename[m.end(1):]
+        # HD/SD in brackets or after an episode number
+        m = re.search(r'(?:[\[\(]|\d{1,3})\s*([HS]D)(TV)?\b', filename)
+        if m:
+            self.resolution = m.group(1)
+            if m.group(2):
+                self.releaseSource.append(m.group(2))
+            return filename[:m.start(1)] + filename[m.end():]
+        # HD/SD at the end
+        m = re.search(r'\b([HS]D)(TV)?$', filename)
+        if m:
+            self.resolution = m.group(1)
+            if m.group(2):
+                self.releaseSource.append(m.group(2))
+            return filename[:m.start()] + filename[m.end():]
+
         return filename
 
     def __extractHash(self, filename):

--- a/trackma/extras/AnimeInfoExtractor.py
+++ b/trackma/extras/AnimeInfoExtractor.py
@@ -94,8 +94,9 @@ class AnimeInfoExtractor():
                 'source': ['TV', 'DVD', 'BluRay', 'BD', 'Blu-Ray', 'BDMV']}
         for k, v in tags.items():
             for tag in v:
-                m = re.search(r'(?:[\(\[](?:|[^\)\]]*?[^0-9a-zA-Z\)\]]))(' +
-                              tag + r')(?:[^0-9a-zA-Z]|$)', filename, flags=re.IGNORECASE)
+                m = re.search(r'[\(\[][^\)\]]*?(' + tag + r')\b',
+                              filename,
+                              flags=re.IGNORECASE)
                 if m:
                     if (k == 'video'):
                         self.videoType.append(tag)

--- a/trackma/extras/AnimeInfoExtractor.py
+++ b/trackma/extras/AnimeInfoExtractor.py
@@ -17,6 +17,8 @@
 import re
 from decimal import Decimal
 
+NO_SUBBER = '###NO#SUBBER#HERE###'
+
 
 class AnimeInfoExtractor():
     """
@@ -102,8 +104,7 @@ class AnimeInfoExtractor():
                     elif (k == 'source'):
                         self.releaseSource.append(tag)
                     # remove the match
-                    filename = filename[:m.start(
-                        1)] + '###NO#SUBBER#HERE###' + filename[m.end(1):]
+                    filename = filename[:m.start(1)] + NO_SUBBER + filename[m.end(1):]
         return filename
 
     def __extractVideoProfile(self, filename):
@@ -160,10 +161,8 @@ class AnimeInfoExtractor():
 
     def __cleanUpBrackets(self, filename):
         # Can get rid of the brackets that won't contain subber
-        filename = re.sub(
-            r'\((?:[^\)]*?)###NO#SUBBER#HERE##(?:.*?)\)', '', filename)
-        filename = re.sub(
-            r'\[(?:[^\]]*?)###NO#SUBBER#HERE##(?:.*?)\]', '', filename)
+        filename = re.sub(r'\((?:[^\)]*?)' + NO_SUBBER + r'(?:.*?)\)', '', filename)
+        filename = re.sub(r'\[(?:[^\]]*?)' + NO_SUBBER + r'(?:.*?)\]', '', filename)
         # Strip any empty sets of brackets
         filename = re.sub(
             r'(?:\[(?:[^0-9a-zA-Z]*?)\])|(?:\((?:[^0-9a-zA-Z]*?)\))', ' ', filename)

--- a/trackma/extras/AnimeInfoExtractor.py
+++ b/trackma/extras/AnimeInfoExtractor.py
@@ -67,7 +67,7 @@ class AnimeInfoExtractor():
         return int(ep)
 
     def __extractExtension(self, filename):
-        m = re.search("\.(\w{3})$", filename)
+        m = re.search(r"\.(\w{3})$", filename)
         if m:
             self.extension = m.group(1)
             filename = filename[:-4]
@@ -76,14 +76,14 @@ class AnimeInfoExtractor():
     def __cleanUpSpaces(self, filename):
         filename = filename.replace('_', ' ')
         if not ' ' in filename:
-            filename = re.sub('([^.])\.([^.])', r'\1 \2', filename)
+            filename = re.sub(r'([^.])\.([^.])', r'\1 \2', filename)
             # to handle .-. case (where - is any single chara)
-            filename = re.sub('([^.])\.([^.])', r'\1 \2', filename)
+            filename = re.sub(r'([^.])\.([^.])', r'\1 \2', filename)
             # If there are still no spaces try replacing hyphens with spaces
             if not ' ' in filename:
-                filename = re.sub('([^\-])-([^\-])', r'\1 \2', filename)
+                filename = re.sub(r'([^\-])-([^\-])', r'\1 \2', filename)
                 # to handle -.- case (where . is any single chara)
-                filename = re.sub('([^\-])-([^\-])', r'\1 \2', filename)
+                filename = re.sub(r'([^\-])-([^\-])', r'\1 \2', filename)
         return filename
 
     def __extractSpecialTags(self, filename):
@@ -92,8 +92,8 @@ class AnimeInfoExtractor():
                 'source': ['TV', 'DVD', 'BluRay', 'BD', 'Blu-Ray', 'BDMV']}
         for k, v in tags.items():
             for tag in v:
-                m = re.search('(?:[\(\[](?:|[^\)\]]*?[^0-9a-zA-Z\)\]]))(' +
-                              tag + ')(?:[^0-9a-zA-Z]|$)', filename, flags=re.IGNORECASE)
+                m = re.search(r'(?:[\(\[](?:|[^\)\]]*?[^0-9a-zA-Z\)\]]))(' +
+                              tag + r')(?:[^0-9a-zA-Z]|$)', filename, flags=re.IGNORECASE)
                 if m:
                     if (k == 'video'):
                         self.videoType.append(tag)
@@ -128,17 +128,17 @@ class AnimeInfoExtractor():
     def __extractResolution(self, filename):
         # Match 3 or 4 chars followed by p, i, or x and 3 or 4 more chars, surrounded by any non-alphanumberic chars
         m = re.search(
-            '(?:[^0-9a-zA-Z])(\d{3,4}(?:p|i|x\d{3,4}))(?:[^0-9a-zA-Z]|$)', filename)
+            r'(?:[^0-9a-zA-Z])(\d{3,4}(?:p|i|x\d{3,4}))(?:[^0-9a-zA-Z]|$)', filename)
         if m:
             self.resolution = m.group(1)
             filename = filename[:m.start(1)] + filename[m.end(1):]
         else:
-            m = re.search('(?:\[|\(|\d)(HD|SD)(?:\]|\)| |\.)', filename)
+            m = re.search(r'(?:\[|\(|\d)(HD|SD)(?:\]|\)| |\.)', filename)
             if m:
                 self.resolution = m.group(1)
                 filename = filename[:m.start(1)] + filename[m.end(1):]
             else:
-                m = re.search('(?:\d{1,3})(HD|SD)(?:[^a-zA-Z])', filename)
+                m = re.search(r'(?:\d{1,3})(HD|SD)(?:[^a-zA-Z])', filename)
                 if m:
                     self.resolution = m.group(1)
                     # Super special case for HD/SD imediately after episode
@@ -147,41 +147,41 @@ class AnimeInfoExtractor():
 
     def __extractHash(self, filename):
         # Match anything in square or round brackets that is 8 hex digits
-        m = re.search('(?:\[|\()((?:[A-F]|[a-f]|\d){8})(?:\]|\))', filename)
+        m = re.search(r'(?:\[|\()((?:[A-F]|[a-f]|\d){8})(?:\]|\))', filename)
         if m:
             self.hash = m.group(1)
             filename = filename[:m.start()] + filename[m.end():]
         return filename
 
     def __checkIfRemux(self, filename):
-        m = re.search('(?:[\(\[][^\)\]]*?[^0-9a-zA-Z\)\]]?)(Remux)(?:[^0-9a-zA-Z]|$)',
+        m = re.search(r'(?:[\(\[][^\)\]]*?[^0-9a-zA-Z\)\]]?)(Remux)(?:[^0-9a-zA-Z]|$)',
                       filename, flags=re.IGNORECASE)
         return True if m else False
 
     def __cleanUpBrackets(self, filename):
         # Can get rid of the brackets that won't contain subber
         filename = re.sub(
-            '\((?:[^\)]*?)###NO#SUBBER#HERE##(?:.*?)\)', '', filename)
+            r'\((?:[^\)]*?)###NO#SUBBER#HERE##(?:.*?)\)', '', filename)
         filename = re.sub(
-            '\[(?:[^\]]*?)###NO#SUBBER#HERE##(?:.*?)\]', '', filename)
+            r'\[(?:[^\]]*?)###NO#SUBBER#HERE##(?:.*?)\]', '', filename)
         # Strip any empty sets of brackets
         filename = re.sub(
-            '(?:\[(?:[^0-9a-zA-Z]*?)\])|(?:\((?:[^0-9a-zA-Z]*?)\))', ' ', filename)
+            r'(?:\[(?:[^0-9a-zA-Z]*?)\])|(?:\((?:[^0-9a-zA-Z]*?)\))', ' ', filename)
         return filename
 
     def __extractSubber(self, filename, remux):
         # Extract the subber from square brackets (or round failing that)
-        m = re.search('\[([^\. ].*?)\]', filename)
+        m = re.search(r'\[([^\. ].*?)\]', filename)
         if m:
             self.subberTag = m.group(1)
             filename = filename[:m.start()] + filename[m.end():]
         else:
-            m = re.search('\(([^\. ].*?)\)', filename)
+            m = re.search(r'\(([^\. ].*?)\)', filename)
             if m:
                 self.subberTag = m.group(1)
                 filename = filename[:m.start()] + filename[m.end():]
             else:
-                m = re.search('{([^\. ].*?)}', filename)
+                m = re.search(r'{([^\. ].*?)}', filename)
                 if m:
                     self.subberTag = m.group(1)
                     filename = filename[:m.start()] + filename[m.end():]
@@ -190,7 +190,7 @@ class AnimeInfoExtractor():
         if remux and not 'remux' in self.subberTag.lower():
             # refind remux and remove it
             m = re.search(
-                '(?:[\(\[][^\)\]]*?[^0-9a-zA-Z\)\]]?)(Remux)(?:[^0-9a-zA-Z]|$)', filename, flags=re.IGNORECASE)
+                r'(?:[\(\[][^\)\]]*?[^0-9a-zA-Z\)\]]?)(Remux)(?:[^0-9a-zA-Z]|$)', filename, flags=re.IGNORECASE)
             if m:
                 filename = filename[:m.start(1)] + filename[m.end(1):]
             if self.subberTag:
@@ -201,7 +201,7 @@ class AnimeInfoExtractor():
 
     def __extractVersion(self, filename):
         # Extract the version number (limit at v7 since V8 is possible in a title...)
-        m = re.search('(?:[^a-zA-Z])v([0-7])(?:[^0-9a-zA-Z]|$)',
+        m = re.search(r'(?:[^a-zA-Z])v([0-7])(?:[^0-9a-zA-Z]|$)',
                       filename, flags=re.IGNORECASE)
         if m:
             self.version = int(m.group(1))
@@ -212,7 +212,7 @@ class AnimeInfoExtractor():
         # Check if this is a volume pack - only relevant for no extension
         if not self.extension:
             m = re.search(
-                '[^0-9a-zA-Z](?:vol(?:ume)?\.? ?)(\d{1,3})(?: ?- ?(?:vol(?:ume)?\.? ?)?(\d{1,3}))?(?:[^0-9a-zA-Z]|$)', filename, flags=re.IGNORECASE)
+                r'[^0-9a-zA-Z](?:vol(?:ume)?\.? ?)(\d{1,3})(?: ?- ?(?:vol(?:ume)?\.? ?)?(\d{1,3}))?(?:[^0-9a-zA-Z]|$)', filename, flags=re.IGNORECASE)
             if m:
                 self.volumeStart = int(m.group(1))
                 if m.group(2):
@@ -223,7 +223,7 @@ class AnimeInfoExtractor():
 
     def __extractPv(self, filename):
         # Check if this is a PV release (not relevant if its a pack)
-        m = re.search(' PV ?(\d)?(?:[^a-zA-Z0-9]|$)', filename)
+        m = re.search(r' PV ?(\d)?(?:[^a-zA-Z0-9]|$)', filename)
         if not self.volumeStart and m:
             self.pv = 0
             if m.group(1):
@@ -234,7 +234,7 @@ class AnimeInfoExtractor():
     def __extractEpisodeNumbers(self, filename):
         # First check for concurrent episodes (with a + or &)
         m = re.search(
-            '[^0-9a-zA-Z](?:E\.?|Ep(?:i|isode)?s?(?: |\.)?)?(\d{1,4})[\+\&](\d{1,4})(?:[^0-9a-zA-Z]|$)', filename, flags=re.IGNORECASE)
+            r'[^0-9a-zA-Z](?:E\.?|Ep(?:i|isode)?s?(?: |\.)?)?(\d{1,4})[\+\&](\d{1,4})(?:[^0-9a-zA-Z]|$)', filename, flags=re.IGNORECASE)
         if m:
             start = int(m.group(1))
             end = int(m.group(2))
@@ -246,10 +246,10 @@ class AnimeInfoExtractor():
             # Check for multiple episodes
             if self.extension:
                 # no spaces allowed around the hyphen
-                ep_search_string = '[^0-9a-zA-Z](?:E\.?|Ep(?:i|isode)?(?: |\.)?)?((?:\d{1,3}|1[0-8]\d{2})(?:\.\d{1})?)-(\d{1,4}(?:\.\d{1})?)(?:[^0-9a-zA-Z]|$)'
+                ep_search_string = r'[^0-9a-zA-Z](?:E\.?|Ep(?:i|isode)?(?: |\.)?)?((?:\d{1,3}|1[0-8]\d{2})(?:\.\d{1})?)-(\d{1,4}(?:\.\d{1})?)(?:[^0-9a-zA-Z]|$)'
             else:
                 # probably a pack... so allow spaces around the hyphen
-                ep_search_string = '[^0-9a-zA-Z](?:E\.?|Ep(?:i|isode)?(?: |\.)?)?((?:\d{1,3}|1[0-8]\d{2})(?:\.\d{1})?) ?- ?(\d{1,4}(?:\.\d{1})?)(?:[^0-9a-zA-Z]|$)'
+                ep_search_string = r'[^0-9a-zA-Z](?:E\.?|Ep(?:i|isode)?(?: |\.)?)?((?:\d{1,3}|1[0-8]\d{2})(?:\.\d{1})?) ?- ?(\d{1,4}(?:\.\d{1})?)(?:[^0-9a-zA-Z]|$)'
             m = re.search(ep_search_string, filename, flags=re.IGNORECASE)
             if m:
                 self.episodeStart = Decimal(m.group(1))
@@ -258,7 +258,7 @@ class AnimeInfoExtractor():
         if not self.episodeStart:
             # Check if there is an episode specifier
             m = re.search(
-                '(?:[^0-9a-zA-Z])(E\.?|Ep(?:i|isode)?(?: |\.)?)(\d{1,}(?:\.\d{1})?)(?:[^\d]|$)', filename, flags=re.IGNORECASE)
+                r'(?:[^0-9a-zA-Z])(E\.?|Ep(?:i|isode)?(?: |\.)?)(\d{1,}(?:\.\d{1})?)(?:[^\d]|$)', filename, flags=re.IGNORECASE)
             if m:
                 self.episodeStart = Decimal(m.group(2))
                 filename = filename[:m.start() + 1]
@@ -266,14 +266,14 @@ class AnimeInfoExtractor():
             # Check any remaining lonely numbers as episode (towards the end has priority)
             # First try outside brackets
             m = re.search(
-                '(?:.*)(?:[^0-9a-zA-Z\.])((?:\d{1,3}|1[0-8]\d{2})(?:\.\d{1})?)(?:[^0-9a-zA-Z]|$)', filename)
+                r'(?:.*)(?:[^0-9a-zA-Z\.])((?:\d{1,3}|1[0-8]\d{2})(?:\.\d{1})?)(?:[^0-9a-zA-Z]|$)', filename)
             if m:
                 self.episodeStart = Decimal(m.group(1))
                 filename = filename[:m.start(1)]
         if not self.episodeStart:
             # then allow brackets
             m = re.search(
-                '(?:.*)(?:[^0-9a-zA-Z\.\[\(])((?:\d{1,3}|1[0-8]\d{2})(?:\.\d{1})?)(?:[^0-9a-zA-Z\]\)]|$)', filename)
+                r'(?:.*)(?:[^0-9a-zA-Z\.\[\(])((?:\d{1,3}|1[0-8]\d{2})(?:\.\d{1})?)(?:[^0-9a-zA-Z\]\)]|$)', filename)
             if m:
                 self.episodeStart = Decimal(m.group(1))
                 filename = filename[:m.start(1)]
@@ -283,26 +283,26 @@ class AnimeInfoExtractor():
         # Unfortunately its very hard to know if there should be brackets in the title...
         # We really should strip brackets... so to anything with brackets in the title: sorry =(
         # Strip anything thats still in brackets, but backup the first case incase it IS the title...
-        m = re.search('\[([^\. ].*?)\]', filename)
+        m = re.search(r'\[([^\. ].*?)\]', filename)
         backup_title = ''
         if m:
             backup_title = m.group(1)
             filename = filename[:m.start()] + filename[m.end():]
         else:
-            m = re.search('\(([^\. ].*?)\)', filename)
+            m = re.search(r'\(([^\. ].*?)\)', filename)
             if m:
                 backup_title = m.group(1)
                 filename = filename[:m.start()] + filename[m.end():]
             else:
-                m = re.search('{([^\. ].*?)}', filename)
+                m = re.search(r'{([^\. ].*?)}', filename)
                 if m:
                     backup_title = m.group(1)
                     filename = filename[:m.start()] + filename[m.end():]
-        filename = re.sub('(?:\[.*?\])|(?:\(.*?\))', ' ', filename)
+        filename = re.sub(r'(?:\[.*?\])|(?:\(.*?\))', ' ', filename)
         filename = filename.strip(' -')
-        filename = re.sub('  (?:.*)', '', filename)
+        filename = re.sub(r'  (?:.*)', '', filename)
         # Strip any unclosed brackets and anything after them
-        filename = re.sub('(.*)(?:[\(\[({].*)$', r'\1', filename)
+        filename = re.sub(r'(.*)(?:[\(\[({].*)$', r'\1', filename)
         self.name = filename.strip(' -')
         if self.name == '':
             self.name = backup_title

--- a/trackma/extras/AnimeInfoExtractor.py
+++ b/trackma/extras/AnimeInfoExtractor.py
@@ -88,7 +88,7 @@ class AnimeInfoExtractor():
         for char in characters:
             if ' ' in filename:
                 break
-            filename = re.sub(r'([^{0}]){0}([^{0}])'.format(re.escape(char)), r'\1 \2', filename)
+            filename = re.sub(r'([^{0}]){0}(?=[^{0}]|$)'.format(re.escape(char)), r'\1 ', filename)
         return filename
 
     def __extractSpecialTags(self, filename):

--- a/trackma/extras/AnimeInfoExtractor.py
+++ b/trackma/extras/AnimeInfoExtractor.py
@@ -228,7 +228,8 @@ class AnimeInfoExtractor():
     def __extractEpisodeNumbers(self, filename):
         # First check for concurrent episodes (with a + or &)
         m = re.search(
-            r'\b(?:S(?:\.|eason)?(\d+))?(?:E\.?|Ep(?:i|isode)?s?[ .]?)?(\d{1,4})[\+\&](\d{1,4})\b',
+            r'\b(?:S(?:\.|eason)?(\d+)\s*)?'
+            r'(?:E\.?|Ep(?:i|isode)?s?[ .]?)?(\d{1,4})[\+\&](\d{1,4})\b',
             filename,
             flags=re.IGNORECASE,
         )
@@ -244,7 +245,7 @@ class AnimeInfoExtractor():
 
         # Check for multiple episodes (with a -)
         ep_search_string = (
-            r'\b(?:S(?:\.|eason)?(\d+))?'
+            r'\b(?:S(?:\.|eason)?(\d+)\s*)?'
             r'(?:E\.?|Ep(?:i|isode)?[ .]?)?'
             r'((?:\d{1,3}|1[0-8]\d{2})(?:\.\d{1})?)'
             # Only allow spaces around the hyphen when we are likely to have a pack
@@ -261,7 +262,7 @@ class AnimeInfoExtractor():
 
         # Check if there is an episode specifier
         m = re.search(
-            r'\b(?:S(?:\.|eason)?(\d+))?(?:E\.?|Ep(?:i|isode)?[ .]?)(\d{1,}(?:\.\d)?)(?:\b|v)',
+            r'\b(?:S(?:\.|eason)?(\d+)\s*)?(?:E\.?|Ep(?:i|isode)?[ .]?)(\d{1,}(?:\.\d)?)(?:\b|v)',
             filename,
             flags=re.IGNORECASE
         )

--- a/trackma/extras/AnimeInfoExtractor.py
+++ b/trackma/extras/AnimeInfoExtractor.py
@@ -312,7 +312,7 @@ class AnimeInfoExtractor():
         # Strip any unclosed brackets and anything after them
         for opening, closing in bracket_pairs:
             filename = re.sub(r'{}r[^{}].*$'.format(opening, closing), '', filename)
-        self.name = filename.strip(' -')
+        self.name = re.sub(r'( - *)+$', '', filename.strip(' '))
         # If we have a subber but no title!? then it must have been a title...
         if self.name == '' and self.subberTag != '':
             self.name = self.subberTag

--- a/trackma/extras/AnimeInfoExtractor.py
+++ b/trackma/extras/AnimeInfoExtractor.py
@@ -89,28 +89,27 @@ class AnimeInfoExtractor():
         return filename
 
     def __extractSpecialTags(self, filename):
-        tags = {'video': ['H264', 'H.264', 'x264', 'XviD', 'DivX', 'MP4'],
-                'audio': ['AC3', 'AAC', 'MP3', 'FLAC'],
-                'source': ['TV', 'DVD', 'BluRay', 'BD', 'Blu-Ray', 'BDMV', 'www', 'WEB']}
-        for k, v in tags.items():
-            for tag in v:
-                m = re.search(r'[\(\[][^\)\]]*?(' + tag + r')\b',
-                              filename,
-                              flags=re.IGNORECASE)
-                if m:
-                    if (k == 'video'):
-                        self.videoType.append(tag)
-                    elif (k == 'audio'):
-                        self.audioType.append(tag)
-                    elif (k == 'source'):
-                        self.releaseSource.append(tag)
-                    # remove the match
-                    filename = filename[:m.start(1)] + NO_SUBBER + filename[m.end(1):]
+        tags = {'video': r'H\.?264|x264|AVC|XviD|DivX|H\.?265|HEVC|AV1',
+                'audio': r'AC3|AAC|MP3|FLAC|E-?AC-?3|Opus|DTS(?:-HD)?',
+                'source': r'TV|DVD|Blu-?Ray|BD|BDMV|www|WEB(?:-DL)?'}
+        for k, tag_re in tags.items():
+            m = re.search(r'[\(\[][^\)\]]*?\b(' + tag_re + r')\b',
+                          filename,
+                          flags=re.IGNORECASE)
+            if m:
+                if k == 'video':
+                    self.videoType.append(m.group(1))
+                elif k == 'audio':
+                    self.audioType.append(m.group(1))
+                elif k == 'source':
+                    self.releaseSource.append(m.group(1))
+                # remove the match
+                filename = filename[:m.start(1)] + NO_SUBBER + filename[m.end(1):]
         return filename
 
     def __extractVideoProfile(self, filename):
         # Check for 8bit/10bit
-        tags_10bit = ['Hi10P', 'Hi10', '10bit', '10 bit', '10-bit']
+        tags_10bit = ['Hi10P', 'Hi10', '10bit', '10 bit', '10-bit', 'YUV420P10']
         tags_8bit = ['8bit', '8-bit']
         for tag in tags_10bit:
             if tag in filename:

--- a/trackma/extras/AnimeInfoExtractor.py
+++ b/trackma/extras/AnimeInfoExtractor.py
@@ -93,7 +93,7 @@ class AnimeInfoExtractor():
 
     def __extractSpecialTags(self, filename):
         tags = {'video': r'H\.?264|x264|AVC|XviD|DivX|H\.?265|HEVC|AV1',
-                'audio': r'AC3|AAC|MP3|FLAC|E-?AC-?3|Opus|DTS(?:-HD)?',
+                'audio': r'AC3|AAC|MP3|FLAC|E-?AC-?3|Opus|DTS(?:-HD)?|TrueHD|L?PCM',
                 'source': r'TV|DVD|Blu-?Ray|BD|BDMV|www|WEB(?:-DL)?'}
         for k, tag_re in tags.items():
             m = re.search(r'[\(\[][^\)\]]*?\b(' + tag_re + r')\b',

--- a/trackma/extras/AnimeInfoExtractor.py
+++ b/trackma/extras/AnimeInfoExtractor.py
@@ -91,7 +91,7 @@ class AnimeInfoExtractor():
     def __extractSpecialTags(self, filename):
         tags = {'video': ['H264', 'H.264', 'x264', 'XviD', 'DivX', 'MP4'],
                 'audio': ['AC3', 'AAC', 'MP3', 'FLAC'],
-                'source': ['TV', 'DVD', 'BluRay', 'BD', 'Blu-Ray', 'BDMV']}
+                'source': ['TV', 'DVD', 'BluRay', 'BD', 'Blu-Ray', 'BDMV', 'www', 'WEB']}
         for k, v in tags.items():
             for tag in v:
                 m = re.search(r'[\(\[][^\)\]]*?(' + tag + r')\b',

--- a/trackma/extras/AnimeInfoExtractor.py
+++ b/trackma/extras/AnimeInfoExtractor.py
@@ -75,12 +75,12 @@ class AnimeInfoExtractor():
 
     def __cleanUpSpaces(self, filename):
         filename = filename.replace('_', ' ')
-        if not ' ' in filename:
+        if ' ' not in filename:
             filename = re.sub(r'([^.])\.([^.])', r'\1 \2', filename)
             # to handle .-. case (where - is any single chara)
             filename = re.sub(r'([^.])\.([^.])', r'\1 \2', filename)
             # If there are still no spaces try replacing hyphens with spaces
-            if not ' ' in filename:
+            if ' ' not in filename:
                 filename = re.sub(r'([^\-])-([^\-])', r'\1 \2', filename)
                 # to handle -.- case (where . is any single chara)
                 filename = re.sub(r'([^\-])-([^\-])', r'\1 \2', filename)
@@ -187,7 +187,7 @@ class AnimeInfoExtractor():
                     filename = filename[:m.start()] + filename[m.end():]
         self.subberTag = self.subberTag.strip(' -')
         # Add the remux string if this was a remux and its not found in the subber tag
-        if remux and not 'remux' in self.subberTag.lower():
+        if remux and 'remux' not in self.subberTag.lower():
             # refind remux and remove it
             m = re.search(
                 r'(?:[\(\[][^\)\]]*?[^0-9a-zA-Z\)\]]?)(Remux)(?:[^0-9a-zA-Z]|$)', filename, flags=re.IGNORECASE)

--- a/trackma/extras/AnimeInfoExtractor.py
+++ b/trackma/extras/AnimeInfoExtractor.py
@@ -318,7 +318,7 @@ class AnimeInfoExtractor():
             self.name = self.subberTag
             self.subberTag = ''
         # Reappend season number
-        if self.season:
+        if self.season and self.season > 1:
             self.name += " {}".format(self.season)
 
     def _processFilename(self):

--- a/trackma/extras/AnimeInfoExtractor.py
+++ b/trackma/extras/AnimeInfoExtractor.py
@@ -111,21 +111,19 @@ class AnimeInfoExtractor():
         return filename
 
     def __extractVideoProfile(self, filename):
-        # Check for 8bit/10bit
-        tags_10bit = ['Hi10P', 'Hi10', '10bit', '10 bit', '10-bit', 'YUV420P10']
-        tags_8bit = ['8bit', '8-bit']
-        for tag in tags_10bit:
-            if tag in filename:
-                self.videoType = ['H264', 'Hi10P']
-                # Don't replace Hi10 coz its a subber name
-                if tag != 'Hi10':
-                    filename = filename.replace(tag, '')
-                return filename
-        if not self.videoType == ['H264', 'Hi10P']:
-            for tag in tags_8bit:
+        # Check for 8bit/10bit/Hi444PP
+        h264_profiles = [
+            (['H264', 'Hi10P'], ['Hi10P', 'Hi10', '10bit', '10 bit', '10-bit', 'YUV420P10']),
+            (['H264', '8bit'], ['8bit', '8-bit']),
+            (['H264', 'Hi444PP'], ['Hi444PP', 'YUV444P10']),
+        ]
+        for to_add, tags in h264_profiles:
+            for tag in tags:
                 if tag in filename:
-                    self.videoType = ['H264', '8bit']
-                    filename = filename.replace(tag, '')
+                    self.videoType = to_add
+                    # Don't replace Hi10 coz its a subber name
+                    if tag != 'Hi10':
+                        filename = filename.replace(tag, '')
                     return filename
         return filename
 


### PR DESCRIPTION
By adding some test cases I collected on a certain website and from #413, I started rewriting a couple matchings in the show parsing algorithm without touching too much of the overarching logic, because that seemed to have worked quite well outside of the collected cases.

Tests are run using `pytest` in the repository root. I didn't add anything for documentation, however, since this is the only part that has tests now.

I tried to make the changes modular and have each commit stand on its own. Particularly notable changes are:

1. S01E01 parsing, where the season number is extracted into a separate attribute and then simply appended to the final show name because I didn't know what else to do it without refactoring. See https://github.com/z411/trackma/commit/c25077c19ff9644ff6cfb30c42dfb7b0161707df for more details. Works decently well for me, anyway, and where it doesn't, altnames help. For matching [Tensei shitara Slime Datta Ken S02E04](https://anilist.co/anime/108511/That-Time-I-Got-Reincarnated-as-a-Slime-Season-2/) properly without an altname, further steps are needed.
2. Not stripping years in parentheses.
3. Tweaking the episode number finder so it only catchs truly isolated episode numbers (i.e. not within an episode title).

Files from #413 I didn't handle because they aren't proper episodes:
```
[Opportunity] The Tatami Galaxy - NCED [BD 720p] [903A3AD6].mkv
[-__-'] Girls und Panzer NCED 04 [BD 1080p FLAC] [88F40C98].mkv
[-__-'] Girls und Panzer NCED OVA Anzio-sen [BD 1080p FLAC] [ED2078EC].mkv
[-__-'] Girls und Panzer NCOP [BD 1080p FLAC] [04ED15D5].mkv
```
We should discuss how to proceed with these (here or later).

Shouldn't conflict with #473, but I would not merge that as-is regardless since it has a lot of inefficient code duplication.