### PR TITLE
Qt: enable sorting after showlist update

### DIFF
--- a/trackma/ui/qt/mainwindow.py
+++ b/trackma/ui/qt/mainwindow.py
@@ -760,12 +760,12 @@ class MainWindow(QMainWindow):
         self.view.model().sourceModel().setMediaInfo(self.mediainfo)
         self.view.model().sourceModel().setShowList(showlist, altnames, library)
         self.view.resizeRowsToContents()
+        self.view.setSortingEnabled(True)
 
         self.s_filter_changed()
 
     def _init_view(self):
         # Set view options
-        self.view.setSortingEnabled(True)
         self.view.sortByColumn(
             self.config['sort_index'], self.config['sort_order'])
 


### PR DESCRIPTION
Fixes a bug where list syncing disables sorting.