### PR TITLE
Gtk: Make ProgressCellRenderer.do_get_size() non-static

### DIFF
--- a/trackma/ui/gtk/showtreeview.py
+++ b/trackma/ui/gtk/showtreeview.py
@@ -461,8 +461,7 @@ class ProgressCellRenderer(Gtk.CellRenderer):
                                  finish-start, h-(h-self._subheight))
                     cr.fill()
 
-    @staticmethod
-    def do_get_size(widget, cell_area):
+    def do_get_size(self, widget, cell_area):
         if cell_area is None:
             return 0, 0, 0, 0
         x = cell_area.x


### PR DESCRIPTION
ProgressCellRenderer.do_get_size is a instance specific method
Using it as static makes gtk raise exceptions
