### PR TITLE
[Redirections] Handle self-redirecting rules

### DIFF
--- a/trackma/extras/redirections.py
+++ b/trackma/extras/redirections.py
@@ -103,6 +103,11 @@ def parse_anime_relations(filename, api, last=None):
                     if not src_id in relations:
                         relations[src_id] = []
                     relations[src_id].append((src_eps, dst_id, dst_eps))
+                    # Handle self-redirecting rules
+                    if m.group(11) == '!':
+                       if not dst_id in relations:
+                           relations[dst_id] = []
+                       relations[dst_id].append((src_eps, dst_id, dst_eps))
                 else:
                     print("Not recognized. " + line)
 


### PR DESCRIPTION
***It's still 31st in my country, but HAPPY NEW YEAR FOLKS! :tada:***
---

Rules that end with `!` should automatically create a new rule where destination ID is redirected to itself.

### Example (taken from [erengy/anime-relations](https://github.com/erengy/anime-relations#example)):

```
# Fate/Zero -> ~ 2nd Season
- 10087|6028|10087:14-25 -> 11741|7658|11741:1-12!
```

The `!` in above rule creates another rule:

```
# Fate/Zero 2nd Season -> ~
- 11741|7658|11741:14-25 -> 11741|7658|11741:1-12
```