### PR TITLE
[Kitsu API] Deals with the case where there is no small/tiny image

### DIFF
--- a/trackma/lib/libkitsu.py
+++ b/trackma/lib/libkitsu.py
@@ -353,7 +353,7 @@ class libkitsu(lib):
                         'my_id': entry['id'],
                         'my_progress': entry['attributes']['progress'],
                         'my_score': float(rating)/4.00 if rating is not None else 0.0,
-                        'my_status': entry['attributes']['status'],
+                        'my_status': status,
                         'my_start_date': self._iso2date(entry['attributes']['startedAt']),
                         'my_finish_date': self._iso2date(entry['attributes']['finishedAt']),
                     })
@@ -560,8 +560,8 @@ class libkitsu(lib):
             # For now I'm just picking the romaji title in these cases.
             'title':       attr['titles'].get('en_jp') or attr.get('canonicalTitle') or attr['titles'].get('en'),
             'total':       total or 0,
-            'image':       attr['posterImage'] and attr['posterImage']['small'],
-            'image_thumb': attr['posterImage'] and attr['posterImage']['tiny'],
+            'image':       attr['posterImage'] and attr['posterImage'].get('small'),
+            'image_thumb': attr['posterImage'] and attr['posterImage'].get('tiny'),
             'start_date':  self._str2date(attr['startDate']),
             'end_date':    self._str2date(attr['endDate']),
             'type':        self.type_translate.get(attr['subtype'], utils.TYPE_UNKNOWN),


### PR DESCRIPTION
In the case of a recent anime, here the content we have back for poster:
```
      "posterImage": {
        "original": "https://kitsu-production-media.s3.us-west-002.backblazeb2.com/anime/44979/poster_image/9f6b8e791778abde38ca7e711327f50e.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=002d6013655cdc00000000003%2F20220116%2Fus-west-002%2Fs3%2Faws4_request&X-Amz-Date=20220116T214041Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=602c57bd3964a1aa4074cefb1f0e39d30a1ff6b46d23cd703cc12097b70959df",
        "meta": {
          "dimensions": {}
        }
      }
```
(for CUE anime / id = 44979)

So we have no small/tiny poster and so trackma keeps crashing