### PR TITLE
Fix Qt UI immediately closing itself

### DIFF
--- a/trackma/ui/qt/__init__.py
+++ b/trackma/ui/qt/__init__.py
@@ -74,7 +74,8 @@ def main(force_qt4=False):
     app.setApplicationName("trackma")
     app.setDesktopFileName("trackma")
     try:
-        MainWindow(debug)
+        # keep the variable around to prevent it from being gc'ed
+        main_window = MainWindow(debug)
         sys.exit(app.exec_())
     except utils.TrackmaFatal as e:
         QMessageBox.critical(None, 'Fatal Error', "{0}".format(e), QMessageBox.Ok)


### PR DESCRIPTION
This feels really bad, but I have no experience with Qt or PyQt to think
of a better solution.

Fixes a regression of #493.

Qt4 is broken for me in general, even on stable, but I also don't have qt4 dependencies in my package manager anymore and would need to built them from the AUR. Since it's very old and we're on Qt6 already, maybe we should remove it?