### PR TITLE
Create episode_missing Hook

### DIFF
--- a/hooks/episode_missing_ani-cli.py
+++ b/hooks/episode_missing_ani-cli.py
@@ -1,0 +1,23 @@
+"""
+ Author: imsamuka
+ Place under ~/.config/trackma/hooks/ or ~/.trackma/hooks/
+
+ When a episode is not found, it executes 'ani-cli' to find and
+ watch it via streaming automatically!
+"""
+
+import shutil
+from trackma import utils
+
+# Executed when trying to watch an episode that don't exists on your library
+def episode_missing(engine, show, episode):
+
+    query = show["title"].strip()
+    anicli = shutil.which("ani-cli") # find 'ani-cli' executable
+    if anicli:
+        args = [anicli, "-q", "best", "-a", str(episode), query]
+        cmd = " ".join(args[:-1]) + f" '{query}'"
+        engine.msg.info("episode_missing", cmd) # Show the command used
+        utils.spawn_process(args)
+    else:
+        engine.msg.info("episode_missing", "ani-cli was not found")

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -73,6 +73,7 @@ class Engine:
                'prompt_for_update': None,
                'prompt_for_add':    None,
                'tracker_state':     None,
+               'episode_missing': None,
                }
 
     def __init__(self, account=None, message_handler=None, accountnum=None):
@@ -943,32 +944,38 @@ class Engine:
         except ValueError:
             raise utils.EngineError('Episode must be numeric.')
 
-        if show:
-            playing_next = False
-            if not playep:
-                playep = show['my_progress'] + 1
-                playing_next = True
+        if not show:
+            raise utils.EngineError('Show given is invalid')
 
-            if show['total'] and playep > show['total']:
-                raise utils.EngineError('Episode beyond limits.')
+        if playep <= 0:
+            playep = show['my_progress'] + 1
 
-            self.msg.info(self.name, "Getting %s %s from library..." %
-                          (show['title'], playep))
+        if show['total'] and playep > show['total']:
+            raise utils.EngineError('Episode beyond limits.')
+
+        self.msg.info(self.name, "Getting '%s' episode '%s' from library..." %
+                        (show['title'], playep))
+
+        try:
             filename = self.get_episode_path(show, playep)
-            endep = playep
+        except utils.EngineError:
+            self.msg.info(self.name, "Episode not found. Calling hooks...")
+            self._emit_signal("episode_missing", show, playep)
+            return []
 
-            if filename:
-                self.msg.info(self.name, 'Found. Starting player...')
-                args = shlex.split(self.config['player'])
+        self.msg.info(self.name, 'Found. Starting player...')
+        args = shlex.split(self.config['player'])
 
-                if len(args) > 0 and shutil.which(args[0]) == None:
-                    raise utils.EngineError(
-                        'Player not found, check your config.json')
+        if not args:
+            raise utils.EngineError('Player not set up, check your config.json')
 
-                args.append(filename)
-                return args
-            else:
-                raise utils.EngineError('Episode file not found.')
+        args[0] = shutil.which(args[0])
+
+        if not args[0]:
+            raise utils.EngineError('Player not found, check your config.json')
+
+        args.append(filename)
+        return args
 
     def undoall(self):
         """Clears the data handler queue and discards any unsynced change."""

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -426,6 +426,8 @@ def spawn_process(arg_list):
     Helper generic function to spawn a subprocess.
     Does a double fork on *nix to prevent zombie processes.
     """
+    if not arg_list:
+        return
 
     if not sys.platform.startswith('win32'):
         try:


### PR DESCRIPTION
Following suggestion on #610, I created a hook that is called whenever `Engine.play_episode()` fails to find a episode on the user library. I also created a hook example file using it, mimicking #610 behavior.