### PR TITLE
[GTK] Improve "play episode" context menu

### DIFF
--- a/trackma/ui/gtk/mainview.py
+++ b/trackma/ui/gtk/mainview.py
@@ -753,7 +753,10 @@ class NotebookPage(Gtk.ScrolledWindow):
         for i in range(1, total + 1):
             mb_playep = Gtk.CheckMenuItem(str(i))
             if i <= show['my_progress']:
-                mb_playep.set_active(True)
+                mb_playep.set_state(Gtk.StateType.INCONSISTENT)
+            elif i == show['my_progress'] + 1:
+                mb_playep.set_label(str(i) + " - Next")
+            mb_playep.set_active(i in library_episodes)
             mb_playep.connect("activate",
                               self._on_mb_activate,
                               ShowEventType.PLAY_EPISODE, i)

--- a/trackma/ui/gtk/mainview.py
+++ b/trackma/ui/gtk/mainview.py
@@ -725,8 +725,7 @@ class NotebookPage(Gtk.ScrolledWindow):
 
         mb_playep = Gtk.MenuItem("Play episode")
         mb_playep.set_submenu(menu_eps)
-        if not menu_eps.get_children():
-            mb_playep.set_state(Gtk.StateType.INSENSITIVE)
+        mb_playep.set_sensitive(bool(menu_eps.get_children()))
         menu.append(mb_playep)
 
         menu.append(mb_info)
@@ -748,15 +747,18 @@ class NotebookPage(Gtk.ScrolledWindow):
             *library_episodes,
             utils.estimate_aired_episodes(show)
         )
+        next_ep = show['my_progress'] + 1
 
         menu_eps = Gtk.Menu()
         for i in range(1, total + 1):
             mb_playep = Gtk.CheckMenuItem(str(i))
-            if i <= show['my_progress']:
-                mb_playep.set_state(Gtk.StateType.INCONSISTENT)
-            elif i == show['my_progress'] + 1:
+            if i == next_ep:
                 mb_playep.set_label(str(i) + " - Next")
+                mb_playep.set_margin_left(10)
+                menu_eps.set_focus_child(mb_playep)
+            mb_playep.set_inconsistent(i < next_ep)
             mb_playep.set_active(i in library_episodes)
+            mb_playep.set_draw_as_radio(True)
             mb_playep.connect("activate",
                               self._on_mb_activate,
                               ShowEventType.PLAY_EPISODE, i)

--- a/trackma/ui/gtk/mainview.py
+++ b/trackma/ui/gtk/mainview.py
@@ -725,6 +725,8 @@ class NotebookPage(Gtk.ScrolledWindow):
 
         mb_playep = Gtk.MenuItem("Play episode")
         mb_playep.set_submenu(menu_eps)
+        if not menu_eps.get_children():
+            mb_playep.set_state(Gtk.StateType.INSENSITIVE)
         menu.append(mb_playep)
 
         menu.append(mb_info)
@@ -740,7 +742,12 @@ class NotebookPage(Gtk.ScrolledWindow):
         menu.popup_at_pointer(event)
 
     def _build_episode_menu(self, show):
-        total = show['total'] or utils.estimate_aired_episodes(show) or 0
+        library_episodes = set(self._engine.library().get(show['id'], ()))
+        total = show['total'] or max(
+            show['my_progress'],
+            *library_episodes,
+            utils.estimate_aired_episodes(show)
+        )
 
         menu_eps = Gtk.Menu()
         for i in range(1, total + 1):


### PR DESCRIPTION
##  Fixed media with 0 or unknown total episodes/chapters showing an empty menu

### Before 

![Anime with unknown total episodes before](https://user-images.githubusercontent.com/62220318/169720038-53ebde6b-facc-4b0c-9b3b-db7b8cded26c.png)

### After
 
![Anime with 0 episodes after](https://user-images.githubusercontent.com/62220318/169720211-80d4f0e9-2bd2-42de-8deb-8c83ac611c71.png)
![Anime with unknown total episodes after](https://user-images.githubusercontent.com/62220318/169720293-0064894d-bda6-45e7-83b3-2ffd046e88ae.png)

## Changed menu style, and added a "present in library" indicator

### Before

![style before](https://user-images.githubusercontent.com/62220318/169720415-2c19bdf6-6899-4a24-ae8d-17854985846d.png)

### After

![style after](https://user-images.githubusercontent.com/62220318/169720432-7499e6a9-0260-40f0-a2a2-dfc0527fe1f1.png)

