### PR TITLE
[Qt] fix account editing

### DIFF
--- a/trackma/ui/qt/accounts.py
+++ b/trackma/ui/qt/accounts.py
@@ -113,9 +113,9 @@ class AccountDialog(QDialog):
                                          password=acct['password'],
                                          api=acct['api'])
             if result:
-                (username, password, api) = result
+                (username, password, api, extra) = result
                 self.accountman.edit_account(
-                    selected_account_num, username, password, api)
+                    selected_account_num, username, password, api, extra)
                 self.rebuild()
         except IndexError:
             self._error("Please select an account.")


### PR DESCRIPTION
When the extra field was added a few years back, it was only added to account creation, not updating. Since tokens expire for some sites, the following error would occur when someone went to update their token after their syncs started getting rejected:
![image](https://user-images.githubusercontent.com/5397662/173765110-c1e94c09-4075-4086-9d2f-9cba3a0d2c70.png)
