### PR TITLE
Qt: Disable buttons in account switcher when they cannot be used

### DIFF
--- a/trackma/ui/qt/mainwindow.py
+++ b/trackma/ui/qt/mainwindow.py
@@ -1240,7 +1240,7 @@ class MainWindow(QMainWindow):
         if not self.accountman_widget:
             self.accountman_create()
         else:
-            self.accountman_widget.update()
+            self.accountman_widget.rebuild()
 
         self.accountman_widget.setModal(True)
         self.accountman_widget.show()


### PR DESCRIPTION
Instead of showing an error that no account has been selected, prevent
clicking the buttons in the first place.

Also properly reset the "Edit" combo when any button is pressed and not
only "Update".

Just something I noticed while testing #618.