### PR TITLE
MAL API: update type_translate dict

### DIFF
--- a/trackma/lib/libmal.py
+++ b/trackma/lib/libmal.py
@@ -96,6 +96,14 @@ class libmal(lib):
         'ova': utils.Type.OVA,
         'ona': utils.Type.OVA,
         'music': utils.Type.OTHER,
+        'unknown': utils.Type.UNKNOWN,
+        'manga': utils.Type.MANGA,
+        'novel': utils.Type.NOVEL,
+        'light_novel': utils.Type.NOVEL,
+        'manhwa': utils.Type.MANGA,
+        'manhua': utils.Type.MANGA,
+        'one_shot': utils.Type.ONE_SHOT,
+        'doujinshi': utils.Type.MANGA,
     }
     
     status_translate = {


### PR DESCRIPTION
trackma crashes when trying to display the results of a (manga) search query.
The `type_translate` dictionary only contained entries for anime, so I've added the missing ones for manga.

I got these entries from the API documentation example response, and I've also added light_novel, since that's apparently also a valid option.

The documentation also lists 'oel' as a type, not sure what that's about so I left that out.

fixes #627 