### PR TITLE
Simplify messenger calls

### DIFF
--- a/trackma/data.py
+++ b/trackma/data.py
@@ -59,7 +59,7 @@ class Data:
         """Checks if the config is correct and creates an API object."""
         self.msg = messenger.with_classname(self.name)
         self.config = config
-        self.msg.info(self.name, "Initializing...")
+        self.msg.info("Initializing...")
 
         # Get filenames
         userfolder = "%s.%s" % (account['username'], account['api'])
@@ -90,7 +90,7 @@ class Data:
 
         # Set mediatype
         mediatype = self.userconfig.get('mediatype')
-        self.msg.info(self.name, "Using %s (%s)" % (libname, mediatype))
+        self.msg.info("Using %s (%s)" % (libname, mediatype))
 
         # Get filenames
         self.queue_file = utils.to_data_path(
@@ -135,7 +135,7 @@ class Data:
 
         """
         # Lock the database
-        self.msg.debug(self.name, "Locking database...")
+        self.msg.debug("Locking database...")
         self._lock()
 
         # Load different caches
@@ -168,8 +168,7 @@ class Data:
                     self.process_queue()
                     self.download_data()
                 except utils.APIError as e:
-                    self.msg.warn(
-                        self.name, "Couldn't download list! Using cache.")
+                    self.msg.warn("Couldn't download list! Using cache.")
                     self._load_cache()
             elif not self.showlist:
                 # If the cache wasn't loaded before, do it now
@@ -195,7 +194,7 @@ class Data:
         as it does necessary operations to close the API and the data handler itself.
 
         """
-        self.msg.debug(self.name, "Unloading...")
+        self.msg.debug("Unloading...")
 
         # Cancel autosend thread
         if self.autosend_timer:
@@ -259,7 +258,7 @@ class Data:
         self._save_queue()
         self._save_cache()
         self._emit_signal('queue_changed', self.queue)
-        self.msg.info(self.name, "Queued add for %s" % show['title'])
+        self.msg.info("Queued add for %s" % show['title'])
 
     def queue_update(self, show, key, value):
         """
@@ -302,8 +301,8 @@ class Data:
         self._save_queue()
         self._save_cache()
         self._emit_signal('queue_changed', self.queue)
-        self.msg.info(self.name, "Queued update for %s" % show['title'])
-        self.msg.debug(self.name, "Queued: {} -> {}".format(key, value))
+        self.msg.info("Queued update for %s" % show['title'])
+        self.msg.debug("Queued: {} -> {}".format(key, value))
 
         # Immediately process the action if necessary
         if self._is_queue_ready():
@@ -344,7 +343,7 @@ class Data:
         self._save_queue()
         self._save_cache()
         self._emit_signal('queue_changed', self.queue)
-        self.msg.info(self.name, "Queued delete for %s" % item['title'])
+        self.msg.info("Queued delete for %s" % item['title'])
 
     def queue_clear(self):
         """Clears the queue completely."""
@@ -352,7 +351,7 @@ class Data:
             self.queue = []
             self._save_queue()
             self._emit_signal('queue_changed', self.queue)
-            self.msg.info(self.name, "Cleared queue.")
+            self.msg.info("Cleared queue.")
 
     def process_queue(self):
         """
@@ -364,7 +363,7 @@ class Data:
 
         """
         if self.queue:
-            self.msg.info(self.name, 'Processing queue...')
+            self.msg.info('Processing queue...')
 
             # Load the cache if it wasn't loaded for some reason
             if not self.showlist:
@@ -405,8 +404,7 @@ class Data:
                     elif operation == 'delete':
                         self.api.delete_show(item)
                     else:
-                        self.msg.warn(
-                            self.name, "Unknown operation in queue (%s), skipping..." % repr(operation))
+                        self.msg.warn("Unknown operation in queue (%s), skipping..." % repr(operation))
 
                     if self.showlist.get(showid):
                         self.showlist[showid]['queued'] = False
@@ -415,16 +413,14 @@ class Data:
                     items_processed.append((show, item))
                     self._emit_signal('queue_changed', self.queue)
                 except utils.APIError as e:
-                    self.msg.warn(
-                        self.name, "Can't process %s, will leave unsynced." % item['title'])
-                    self.msg.debug(self.name, "Info: %s" % e)
+                    self.msg.warn("Can't process %s, will leave unsynced." % item['title'])
+                    self.msg.debug("Info: %s" % e)
                     items_failed.append(item)
                 except NotImplementedError:
-                    self.msg.warn(
-                        self.name, "Operation not implemented in API. Skipping...")
+                    self.msg.warn("Operation not implemented in API. Skipping...")
                     items_failed.append(item)
                 # except TypeError:
-                #    self.msg.warn(self.name, "%s not in list, unexpected. Not changing queued status." % showid)
+                #    self.msg.warn("%s not in list, unexpected. Not changing queued status." % showid)
 
             if items_failed:
                 self.queue += items_failed
@@ -434,7 +430,7 @@ class Data:
             self._save_queue()
             self._emit_signal('sync_complete', items_processed)
         else:
-            self.msg.debug(self.name, 'No items in queue.')
+            self.msg.debug('No items in queue.')
 
         self.meta['lastsend'] = time.time()
 
@@ -506,45 +502,45 @@ class Data:
             self.autosend_timer.start()
 
     def _load_cache(self):
-        self.msg.debug(self.name, "Reading cache...")
+        self.msg.debug("Reading cache...")
         self.showlist = utils.load_data(self.cache_file)
 
     def _save_cache(self):
-        self.msg.debug(self.name, "Saving cache...")
+        self.msg.debug("Saving cache...")
         utils.save_data(self.showlist, self.cache_file)
 
     def _load_info(self):
-        self.msg.debug(self.name, "Reading info DB...")
+        self.msg.debug("Reading info DB...")
         self.infocache = utils.load_data(self.info_file)
 
     def _save_info(self):
-        self.msg.debug(self.name, "Saving info DB...")
+        self.msg.debug("Saving info DB...")
         utils.save_data(self.infocache, self.info_file)
 
     def _load_userconfig(self):
-        self.msg.debug(self.name, "Reading userconfig...")
+        self.msg.debug("Reading userconfig...")
         self.userconfig = utils.parse_config(
             self.userconfig_file, utils.userconfig_defaults)
 
     def _save_userconfig(self):
-        self.msg.debug(self.name, "Saving userconfig...")
+        self.msg.debug("Saving userconfig...")
         utils.save_config(self.userconfig, self.userconfig_file)
 
     def _load_queue(self):
-        self.msg.debug(self.name, "Reading queue...")
+        self.msg.debug("Reading queue...")
         self.queue = utils.load_data(self.queue_file)
 
     def _save_queue(self):
-        self.msg.debug(self.name, "Saving queue...")
+        self.msg.debug("Saving queue...")
         utils.save_data(self.queue, self.queue_file)
 
     def _load_meta(self):
-        self.msg.debug(self.name, "Reading metadata...")
+        self.msg.debug("Reading metadata...")
         loadedmeta = utils.load_data(self.meta_file)
         self.meta.update(loadedmeta)
 
     def _save_meta(self):
-        self.msg.debug(self.name, "Saving metadata...")
+        self.msg.debug("Saving metadata...")
         utils.save_data(self.meta, self.meta_file)
 
     def download_data(self):

--- a/trackma/data.py
+++ b/trackma/data.py
@@ -57,7 +57,7 @@ class Data:
 
     def __init__(self, messenger, config, account, mediatype):
         """Checks if the config is correct and creates an API object."""
-        self.msg = messenger
+        self.msg = messenger.with_classname(self.name)
         self.config = config
         self.msg.info(self.name, "Initializing...")
 
@@ -123,7 +123,7 @@ class Data:
             raise utils.DataFatal("Invalid signal.")
 
     def set_message_handler(self, message_handler):
-        self.msg = message_handler
+        self.msg = message_handler.with_classname(self.name)
         self.api.set_message_handler(self.msg)
 
     def start(self):

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -97,9 +97,9 @@ class Engine:
         userfolder = "%s.%s" % (account['username'], account['api'])
         utils.make_dir(utils.to_data_path(userfolder))
 
-        self.msg.info(self.name, 'Trackma v{0} - using account {1}({2}).'.format(
+        self.msg.info('Trackma v{0} - using account {1}({2}).'.format(
             utils.VERSION, account['username'], account['api']))
-        self.msg.info(self.name, 'Reading config files...')
+        self.msg.info('Reading config files...')
         try:
             self.config = utils.parse_config(
                 self.configfile, utils.config_defaults)
@@ -109,7 +109,7 @@ class Engine:
         # Expand media directories and ignore those that don't exist
         if isinstance(self.config['searchdir'], str):
             # Compatibility: Turn a string of a single directory into a list
-            self.msg.debug(self.name, "Fixing string searchdir to list.")
+            self.msg.debug("Fixing string searchdir to list.")
             self.config['searchdir'] = [self.config['searchdir']]
 
         self.searchdirs = [path for path in utils.expand_paths(
@@ -154,7 +154,7 @@ class Engine:
             try:
                 self.set_episode(show['id'], episode)
             except utils.TrackmaError as e:
-                self.msg.warn(self.name, "Can't update episode: {}".format(e))
+                self.msg.warn("Can't update episode: {}".format(e))
 
     def _tracker_unrecognised(self, show, episode):
         if self.config['tracker_not_found_prompt']:
@@ -175,12 +175,12 @@ class Engine:
         for module in self.hooks_available:
             method = getattr(module, signal, None)
             if method is not None:
-                self.msg.debug(self.name, "Calling hook {}:{}...".format(
+                self.msg.debug("Calling hook {}:{}...".format(
                     module.__name__, signal))
                 try:
                     method(self, *args)
                 except Exception as err:
-                    self.msg.warn(self.name, "Exception on hook {}:{}: {}".format(
+                    self.msg.warn("Exception on hook {}:{}: {}".format(
                         module.__name__, signal, err))
 
     def _get_tracker_list(self, filter_num=None):
@@ -191,7 +191,7 @@ class Engine:
             source_list = []
             for status in filter_num:
                 if status is not self.mediainfo['statuses_finish']:
-                    self.msg.debug(self.name, "Scanning for "
+                    self.msg.debug("Scanning for "
                                    "{}".format(self.mediainfo['statuses_dict'][status]))
                     source_list = source_list + self.filter_list(status)
         else:
@@ -217,7 +217,7 @@ class Engine:
     def _cleanup(self):
         # If the engine wasn't closed for whatever reason, do it
         if self.loaded:
-            self.msg.info(self.name, "Forcing exit...")
+            self.msg.info("Forcing exit...")
             self.data_handler.unload(True)
             if self.tracker:
                 self.tracker.disable()
@@ -257,38 +257,35 @@ class Engine:
         if redirections.supports(api, mediatype):
             if utils.file_exists(utils.to_config_path('anime-relations.txt')):
                 fname = utils.to_config_path('anime-relations.txt')
-                self.msg.debug(
-                    self.name, "Using user-provided redirection file.")
+                self.msg.debug("Using user-provided redirection file.")
             else:
                 fname = utils.to_data_path('anime-relations.txt')
                 if self.config['redirections_time'] and (
                         not utils.file_exists(fname) or
                         utils.file_older_than(fname, self.config['redirections_time'] * 86400)):
-                    self.msg.info(self.name, "Syncing redirection file...")
-                    self.msg.debug(self.name, "Syncing from: %s" %
+                    self.msg.info("Syncing redirection file...")
+                    self.msg.debug("Syncing from: %s" %
                                    self.config['redirections_url'])
                     utils.sync_file(fname, self.config['redirections_url'])
 
             if not utils.file_exists(fname):
-                self.msg.debug(
-                    self.name, "Defaulting to repo provided redirections file.")
+                self.msg.debug("Defaulting to repo provided redirections file.")
                 fname = utils.DATADIR + '/anime-relations/anime-relations.txt'
 
-            self.msg.info(self.name, "Parsing redirection file...")
+            self.msg.info("Parsing redirection file...")
             try:
                 self.redirections = redirections.parse_anime_relations(
                     fname, api)
             except Exception as e:
-                self.msg.warn(self.name, "Error parsing anime-relations.txt!")
-                self.msg.debug(self.name, "{}".format(e))
+                self.msg.warn("Error parsing anime-relations.txt!")
+                self.msg.debug("{}".format(e))
 
         # Rescan library if necessary
         if self.config['library_autoscan']:
             try:
                 self.scan_library()
             except utils.TrackmaError as e:
-                self.msg.warn(
-                    self.name, "Can't auto-scan library: {}".format(e))
+                self.msg.warn("Can't auto-scan library: {}".format(e))
 
         # Load hook files
         if self.config['use_hooks']:
@@ -296,27 +293,25 @@ class Engine:
             if os.path.isdir(hooks_dir):
                 import pkgutil
 
-                self.msg.info(self.name, "Importing user hooks...")
+                self.msg.info("Importing user hooks...")
                 for loader, name, ispkg in pkgutil.iter_modules([hooks_dir]):
                     # List all the hook files in the hooks folder, import them
                     # and call the init() function if they have them
                     # We build the list "hooks available" with the loaded modules
                     # for later calls.
                     try:
-                        self.msg.debug(
-                            self.name, "Importing hook {}...".format(name))
+                        self.msg.debug("Importing hook {}...".format(name))
                         module = loader.find_module(name).load_module(name)
                         if hasattr(module, 'init'):
                             module.init(self)
                         self.hooks_available.append(module)
                     except ImportError:
-                        self.msg.warn(
-                            self.name, "Error importing hook {}.".format(name))
-                        self.msg.exception(self.name, sys.exc_info())
+                        self.msg.warn("Error importing hook {}.".format(name))
+                        self.msg.exception(sys.exc_info())
 
         # Start tracker
         if self.mediainfo.get('can_play') and self.config['tracker_enabled']:
-            self.msg.debug(self.name, "Initializing tracker...")
+            self.msg.debug("Initializing tracker...")
             try:
                 TrackerClass = self._get_tracker_class(
                     self.config['tracker_type'])
@@ -335,9 +330,9 @@ class Engine:
                     'unrecognised', self._tracker_unrecognised)
                 self.tracker.connect_signal('state', self._tracker_state)
             except ImportError:
-                self.msg.warn(self.name, "Couldn't import specified tracker: {}".format(
+                self.msg.warn("Couldn't import specified tracker: {}".format(
                     self.config['tracker_type']))
-                self.msg.exception(self.name, sys.exc_info())
+                self.msg.exception(sys.exc_info())
 
         self.loaded = True
         return True
@@ -351,22 +346,22 @@ class Engine:
 
         """
         if self.loaded:
-            self.msg.info(self.name, "Unloading...")
+            self.msg.info("Unloading...")
             self.data_handler.unload()
             if self.tracker:
                 self.tracker.disable()
 
             # If there are loaded hooks, unload them
-            self.msg.info(self.name, "Unloading user hooks...")
+            self.msg.info("Unloading user hooks...")
             for module in self.hooks_available.copy():
-                self.msg.debug(self.name, "Unloading hook {}...".format(
+                self.msg.debug("Unloading hook {}...".format(
                     module.__name__))
                 try:
                     if hasattr(module, 'destroy'):
                         module.destroy(self)
                     self.hooks_available.remove(module)
                 except Exception as err:
-                    self.msg.warn(self.name, "Error destroying hook {}: {}".format(
+                    self.msg.warn("Error destroying hook {}: {}".format(
                         module.__name__, err))
 
             self.loaded = False
@@ -431,11 +426,11 @@ class Engine:
             raise utils.EngineError("Show not found.")
         elif filename:
             # Guess show by filename
-            self.msg.debug(self.name, "Guessing by filename.")
+            self.msg.debug("Guessing by filename.")
 
             aie = AnimeInfoExtractor(filename)
             (show_title, ep) = aie.getName(), aie.getEpisode()
-            self.msg.debug(self.name, "Guessed {}".format(show_title))
+            self.msg.debug("Guessed {}".format(show_title))
 
             if show_title:
                 tracker_list = self._get_tracker_list()
@@ -546,7 +541,7 @@ class Engine:
             raise utils.EngineError("Show already at episode %d" % newep)
 
         # Change episode
-        self.msg.info(self.name, "Updating show %s to episode %d..." %
+        self.msg.info("Updating show %s to episode %d..." %
                       (show['title'], newep))
         self.data_handler.queue_update(show, 'my_progress', newep)
 
@@ -566,15 +561,13 @@ class Engine:
                         self.set_status(
                             show['id'], self._guess_new_finish(show))
                     else:
-                        self.msg.warn(
-                            self.name, "Updated episode but status won't be changed until a score is set.")
+                        self.msg.warn("Updated episode but status won't be changed until a score is set.")
                 elif newep == 1 and self.mediainfo.get('statuses_start'):
                     # Change to start status
                     self.set_status(show['id'], self._guess_new_start(show))
             except utils.EngineError as e:
                 # Only warn about engine errors since status change here is not critical
-                self.msg.warn(
-                    self.name, 'Updated episode but status wasn\'t changed: %s' % e)
+                self.msg.warn('Updated episode but status wasn\'t changed: %s' % e)
 
         # Change dates if required
         if self.config['auto_date_change'] and self.mediainfo.get('can_date'):
@@ -589,8 +582,7 @@ class Engine:
                 self.set_dates(show['id'], start_date, finish_date)
             except utils.EngineError as e:
                 # Only warn about engine errors since date change here is not critical
-                self.msg.warn(
-                    self.name, 'Updated episode but dates weren\'t changed: %s' % e)
+                self.msg.warn('Updated episode but dates weren\'t changed: %s' % e)
 
         # Update the tracker with the new information
         self._update_tracker()
@@ -646,7 +638,7 @@ class Engine:
             raise utils.EngineError("Score already at %s" % newscore)
 
         # Change score
-        self.msg.info(self.name, "Updating show %s to score %s..." %
+        self.msg.info("Updating show %s to score %s..." %
                       (show['title'], newscore))
         self.data_handler.queue_update(show, 'my_score', newscore)
 
@@ -667,8 +659,7 @@ class Engine:
                 self.set_status(show['id'], self._guess_new_finish(show))
             except utils.EngineError as e:
                 # Only warn about engine errors since status change here is not critical
-                self.msg.warn(
-                    self.name, 'Updated episode but status wasn\'t changed: %s' % e)
+                self.msg.warn('Updated episode but status wasn\'t changed: %s' % e)
 
         return show
 
@@ -700,7 +691,7 @@ class Engine:
 
         # Change status
         old_status = show['my_status']
-        self.msg.info(self.name, "Updating show %s status to %s..." %
+        self.msg.info("Updating show %s status to %s..." %
                       (show['title'], _statuses[newstatus]))
         self.data_handler.queue_update(show, 'my_status', newstatus)
 
@@ -725,7 +716,7 @@ class Engine:
             raise utils.EngineError("Tags already %s" % newtags)
 
         # Change score
-        self.msg.info(self.name, "Updating show %s to tags '%s'..." %
+        self.msg.info("Updating show %s to tags '%s'..." %
                       (show['title'], newtags))
         self.data_handler.queue_update(show, 'my_tags', newtags)
 
@@ -773,15 +764,14 @@ class Engine:
                     'statuses_library', self.mediainfo['statuses_start'])
 
         if rescan:
-            self.msg.info(
-                self.name, "Scanning local library (overriding cache)...")
+            self.msg.info("Scanning local library (overriding cache)...")
         else:
-            self.msg.info(self.name, "Scanning local library...")
+            self.msg.info("Scanning local library...")
 
         tracker_list = self._get_tracker_list(my_status)
 
         for searchdir in self.searchdirs:
-            self.msg.debug(self.name, "Directory: %s" % searchdir)
+            self.msg.debug("Directory: %s" % searchdir)
 
             # Do a full listing of the media directory
             for fullpath, filename in utils.regex_find_videos(searchdir):
@@ -791,7 +781,7 @@ class Engine:
                 (library, library_cache) = self._add_show_to_library(
                     library, library_cache, rescan, fullpath, filename, tracker_list)
 
-            self.msg.debug(self.name, "Time: %s" % (time.time() - t))
+            self.msg.debug("Time: %s" % (time.time() - t))
             self.data_handler.library_save(library)
             self.data_handler.library_cache_save(library_cache)
         return library
@@ -807,8 +797,7 @@ class Engine:
             if show_id and show_id in library \
                     and show_ep and show_ep in library[show_id].keys():
                 if library[show_id][show_ep] == fullpath:
-                    self.msg.debug(
-                        self.name, "File removed from local library: %s" % fullpath)
+                    self.msg.debug("File removed from local library: %s" % fullpath)
                     library_cache.pop(filename, None)
                     library[show_id].pop(show_ep, None)
 
@@ -835,10 +824,9 @@ class Engine:
                     (show_ep_start, show_ep_end) = show_ep
                 else:
                     show_ep_start = show_ep_end = show_ep
-                self.msg.debug(self.name, "File in cache: {}".format(fullpath))
+                self.msg.debug("File in cache: {}".format(fullpath))
             else:
-                self.msg.debug(
-                    self.name, "File in cache but skipped: {}".format(fullpath))
+                self.msg.debug("File in cache but skipped: {}".format(fullpath))
                 return library, library_cache
         else:
             # If the filename has not been seen, extract
@@ -851,8 +839,7 @@ class Engine:
             if show_title:
                 show = utils.guess_show(show_title, tracker_list)
                 if show:
-                    self.msg.debug(
-                        self.name, "Adding to library: {}".format(fullpath))
+                    self.msg.debug("Adding to library: {}".format(fullpath))
 
                     if show_ep_start == show_ep_end:
                         # TODO : Support redirections for episode ranges
@@ -860,7 +847,7 @@ class Engine:
                             (show, show_ep_start), self.redirections, tracker_list)
                         show_ep_end = show_ep_start = show_ep
 
-                        self.msg.debug(self.name, "Redirected to: {} {}".format(
+                        self.msg.debug("Redirected to: {} {}".format(
                             show['title'], show_ep))
                         library_cache[filename] = (show['id'], show_ep)
                     else:
@@ -869,13 +856,11 @@ class Engine:
 
                     show_id = show['id']
                 else:
-                    self.msg.debug(self.name,
-                                   "Unable to match '{}', skipping: {}"
+                    self.msg.debug("Unable to match '{}', skipping: {}"
                                    .format(show_title, fullpath))
                     library_cache[filename] = None
             else:
-                self.msg.debug(
-                    self.name, "Not recognized, skipping: {}".format(fullpath))
+                self.msg.debug("Not recognized, skipping: {}".format(fullpath))
                 library_cache[filename] = None
 
         # After we got our information, add it to our library
@@ -910,7 +895,7 @@ class Engine:
         library = self.library()
         newep = []
 
-        self.msg.info(self.name, 'Looking for random episode.')
+        self.msg.info('Looking for random episode.')
 
         for showid, eps in library.items():
             try:
@@ -952,17 +937,17 @@ class Engine:
         if show['total'] and playep > show['total']:
             raise utils.EngineError('Episode beyond limits.')
 
-        self.msg.info(self.name, "Getting '%s' episode '%s' from library..." %
+        self.msg.info("Getting '%s' episode '%s' from library..." %
                         (show['title'], playep))
 
         try:
             filename = self.get_episode_path(show, playep)
         except utils.EngineError:
-            self.msg.info(self.name, "Episode not found. Calling hooks...")
+            self.msg.info("Episode not found. Calling hooks...")
             self._emit_signal("episode_missing", show, playep)
             return []
 
-        self.msg.info(self.name, 'Found. Starting player...')
+        self.msg.info('Found. Starting player...')
         args = shlex.split(self.config['player'])
 
         if not args:
@@ -988,11 +973,10 @@ class Engine:
         if newname is not None:
             if newname == '':
                 self.data_handler.altname_clear(showid)
-                self.msg.info(self.name, 'Cleared alternate name.')
+                self.msg.info('Cleared alternate name.')
             else:
                 self.data_handler.altname_set(showid, newname)
-                self.msg.info(
-                    self.name, 'Changed alternate name to %s.' % newname)
+                self.msg.info('Changed alternate name to %s.' % newname)
             # Update the tracker with the new altname
             self._update_tracker()
         else:
@@ -1036,8 +1020,7 @@ class Engine:
     def _searchdir_exists(self, path):
         """Variation of dir_exists that warns the user if the path doesn't exist."""
         if not utils.dir_exists(path):
-            self.msg.warn(
-                self.name, "The specified media directory {} doesn't exist!".format(path))
+            self.msg.warn("The specified media directory {} doesn't exist!".format(path))
             return False
         return True
 

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -75,7 +75,7 @@ class Engine:
                }
 
     def __init__(self, account=None, message_handler=None, accountnum=None):
-        self.msg = messenger.Messenger(message_handler)
+        self.msg = messenger.Messenger(message_handler, self.name)
 
         # Utility parameter to get the account from the account manager
         if accountnum:
@@ -231,7 +231,7 @@ class Engine:
 
     def set_message_handler(self, message_handler):
         """Changes the message handler function on the fly."""
-        self.msg = messenger.Messenger(message_handler)
+        self.msg = messenger.Messenger(message_handler, self.name)
         self.data_handler.set_message_handler(self.msg)
 
     def start(self):

--- a/trackma/lib/lib.py
+++ b/trackma/lib/lib.py
@@ -68,7 +68,7 @@ class lib:
     def __init__(self, messenger, account, userconfig):
         """Initializes the API"""
         self.userconfig = userconfig
-        self.msg = messenger
+        self.msg = messenger.with_classname(self.name)
         self.msg.info(self.name, 'Initializing...')
 
         if not userconfig.get('mediatype'):
@@ -160,4 +160,4 @@ class lib:
         return self.mediatypes[self.mediatype]
 
     def set_message_handler(self, message_handler):
-        self.msg = message_handler
+        self.msg = message_handler.with_classname(self.name)

--- a/trackma/lib/lib.py
+++ b/trackma/lib/lib.py
@@ -69,7 +69,7 @@ class lib:
         """Initializes the API"""
         self.userconfig = userconfig
         self.msg = messenger.with_classname(self.name)
-        self.msg.info(self.name, 'Initializing...')
+        self.msg.info('Initializing...')
 
         if not userconfig.get('mediatype'):
             userconfig['mediatype'] = self.default_mediatype

--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -212,7 +212,7 @@ class libanilist(lib):
         return True
 
     def _refresh_user_info(self):
-        self.msg.info(self.name, 'Refreshing user details...')
+        self.msg.info('Refreshing user details...')
         query = '{Viewer{ id name avatar{large} options{titleLanguage displayAdultContent} mediaListOptions{scoreFormat} }}'
         data = self._request(query)['data']['Viewer']
 
@@ -224,7 +224,7 @@ class libanilist(lib):
 
     def fetch_list(self):
         self.check_credentials()
-        self.msg.info(self.name, 'Downloading list...')
+        self.msg.info('Downloading list...')
 
         query = '''query ($id: Int!, $listType: MediaType) {
   MediaListCollection (userId: $id, type: $listType) {
@@ -359,24 +359,24 @@ fragment mediaListEntry on MediaList {
 
     def add_show(self, item):
         self.check_credentials()
-        self.msg.info(self.name, "Adding item %s..." % item['title'])
+        self.msg.info("Adding item %s..." % item['title'])
         return self._update_entry(item)
 
     def update_show(self, item):
         self.check_credentials()
-        self.msg.info(self.name, "Updating item %s..." % item['title'])
+        self.msg.info("Updating item %s..." % item['title'])
         self._update_entry(item)
 
     def delete_show(self, item):
         self.check_credentials()
-        self.msg.info(self.name, "Deleting item %s..." % item['title'])
+        self.msg.info("Deleting item %s..." % item['title'])
         query = 'mutation ($id: Int) {DeleteMediaListEntry(id: $id){deleted} }'
         variables = {'id': item['my_id']}
         self._request(query, variables)
 
     def search(self, criteria, method):
         self.check_credentials()
-        self.msg.info(self.name, "Searching for {}...".format(criteria))
+        self.msg.info("Searching for {}...".format(criteria))
 
         if method == utils.SearchMethod.KW:
             query = "query ($query: String, $type: MediaType) { Page { media(search: $query, type: $type) {"

--- a/trackma/lib/libkitsu.py
+++ b/trackma/lib/libkitsu.py
@@ -219,12 +219,12 @@ class libkitsu(lib):
         }
 
         if refresh:
-            self.msg.info(self.name, 'Refreshing access token...')
+            self.msg.info('Refreshing access token...')
 
             params['grant_type'] = 'refresh_token'
             params['refresh_token'] = self._get_userconfig('refresh_token')
         else:
-            self.msg.info(self.name, 'Requesting access token...')
+            self.msg.info('Requesting access token...')
 
             params['grant_type'] = 'password'
             params['username'] = self.username
@@ -246,7 +246,7 @@ class libkitsu(lib):
         self._emit_signal('userconfig_changed')
 
     def _refresh_user_info(self):
-        self.msg.info(self.name, 'Refreshing user details...')
+        self.msg.info('Refreshing user details...')
         params = {
             "filter[self]": 'true',
         }
@@ -279,7 +279,7 @@ class libkitsu(lib):
         """Queries the full list from the remote server.
         Returns the list if successful, False otherwise."""
         self.check_credentials()
-        self.msg.info(self.name, 'Downloading list...')
+        self.msg.info('Downloading list...')
 
         try:
             showlist = dict()
@@ -329,7 +329,7 @@ class libkitsu(lib):
             i = 1
 
             while url:
-                self.msg.info(self.name, 'Getting page {}...'.format(i))
+                self.msg.info('Getting page {}...'.format(i))
 
                 data = self._request('GET', url)
                 data_json = json.loads(data)
@@ -398,7 +398,7 @@ class libkitsu(lib):
     def add_show(self, item):
         """Adds a new show in the server"""
         self.check_credentials()
-        self.msg.info(self.name, "Adding show %s..." % item['title'])
+        self.msg.info("Adding show %s..." % item['title'])
 
         data = self._build_data(item)
 
@@ -416,7 +416,7 @@ class libkitsu(lib):
     def update_show(self, item):
         """Sends a show update to the server"""
         self.check_credentials()
-        self.msg.info(self.name, "Updating show %s..." % item['title'])
+        self.msg.info("Updating show %s..." % item['title'])
 
         data = self._build_data(item)
 
@@ -431,7 +431,7 @@ class libkitsu(lib):
     def delete_show(self, item):
         """Sends a show delete to the server"""
         self.check_credentials()
-        self.msg.info(self.name, "Deleting show %s..." % item['title'])
+        self.msg.info("Deleting show %s..." % item['title'])
 
         try:
             self._request('DELETE', self.prefix +
@@ -442,7 +442,7 @@ class libkitsu(lib):
             raise utils.APIError('Error deleting: ' + str(e.reason))
 
     def search(self, query, method):
-        self.msg.info(self.name, "Searching for %s..." % query)
+        self.msg.info("Searching for %s..." % query)
 
         values = {
             "filter[text]": query,
@@ -511,7 +511,7 @@ class libkitsu(lib):
         try:
             return datetime.datetime.strptime(string, "%Y-%m-%d")
         except Exception:
-            self.msg.debug(self.name, 'Invalid date {}'.format(string))
+            self.msg.debug('Invalid date {}'.format(string))
             return None  # Ignore date if it's invalid
 
     def _iso2date(self, string):
@@ -521,7 +521,7 @@ class libkitsu(lib):
         try:
             return datetime.datetime.strptime(string, "%Y-%m-%dT%H:%M:%S.%fZ").date()
         except Exception:
-            self.msg.debug(self.name, 'Invalid date {}'.format(string))
+            self.msg.debug('Invalid date {}'.format(string))
             return None  # Ignore date if it's invalid
 
     def _guess_status(self, start_date, end_date):

--- a/trackma/lib/libmal.py
+++ b/trackma/lib/libmal.py
@@ -169,9 +169,9 @@ class libmal(lib):
         if post:
             post = urllib.parse.urlencode(post).encode('utf-8')
             content_type = 'application/x-www-form-urlencoded'
-            self.msg.debug(self.name, "POST data: " + str(post))
+            self.msg.debug("POST data: " + str(post))
 
-        self.msg.debug(self.name, method + " URL: " + url)
+        self.msg.debug(method + " URL: " + url)
         request = urllib.request.Request(url, post)
         request.get_method = lambda: method
 
@@ -209,12 +209,12 @@ class libmal(lib):
         }
 
         if refresh:
-            self.msg.info(self.name, 'Refreshing access token...')
+            self.msg.info('Refreshing access token...')
 
             params['grant_type'] = 'refresh_token'
             params['refresh_token'] = self._get_userconfig('refresh_token')
         else:
-            self.msg.info(self.name, 'Requesting access token...')
+            self.msg.info('Requesting access token...')
 
             params['code'] = self.pin
             params['code_verifier'] = self.code_verifier
@@ -266,7 +266,7 @@ class libmal(lib):
         i = 1
         
         while url:
-            self.msg.info(self.name, 'Downloading list (page %d)...' % i)
+            self.msg.info('Downloading list (page %d)...' % i)
             data = self._request('GET', url, auth=True)
             for item in data['data']:
                 showid = item['node']['id']
@@ -295,22 +295,22 @@ class libmal(lib):
 
     def add_show(self, item):
         self.check_credentials()
-        self.msg.info(self.name, "Adding item %s..." % item['title'])
+        self.msg.info("Adding item %s..." % item['title'])
         self._update_entry(item)
 
     def update_show(self, item):
         self.check_credentials()
-        self.msg.info(self.name, "Updating item %s..." % item['title'])
+        self.msg.info("Updating item %s..." % item['title'])
         self._update_entry(item)
     
     def delete_show(self, item):
         self.check_credentials()
-        self.msg.info(self.name, "Deleting item %s..." % item['title'])
+        self.msg.info("Deleting item %s..." % item['title'])
         data = self._request('DELETE', self.query_url + '/%s/%d/my_list_status' % (self.mediatype, item['id']), auth=True)
     
     def search(self, criteria, method):
         self.check_credentials()
-        self.msg.info(self.name, "Searching for {}...".format(criteria))
+        self.msg.info("Searching for {}...".format(criteria))
         
         fields = 'alternative_titles,end_date,genres,id,main_picture,mean,media_type,' + self.total_str + ',popularity,rating,start_date,status,studios,synopsis,title'
         params = {'fields': fields, 'nsfw': 'true'}
@@ -406,5 +406,5 @@ class libmal(lib):
         try:
             return datetime.datetime.strptime(string, "%Y-%m-%d")
         except Exception:
-            self.msg.debug(self.name, 'Invalid date {}'.format(string))
+            self.msg.debug('Invalid date {}'.format(string))
             return None  # Ignore date if it's invalid

--- a/trackma/lib/libshikimori.py
+++ b/trackma/lib/libshikimori.py
@@ -153,7 +153,7 @@ class libshikimori(lib):
             content_type = 'application/json'
 
         request = urllib.request.Request(url, post)
-        self.msg.debug(self.name, "URL: %s" % url)
+        self.msg.debug("URL: %s" % url)
         request.get_method = lambda: method
 
         if content_type:
@@ -185,12 +185,12 @@ class libshikimori(lib):
         }
 
         if refresh:
-            self.msg.info(self.name, 'Refreshing access token...')
+            self.msg.info('Refreshing access token...')
 
             params['grant_type'] = 'refresh_token'
             params['refresh_token'] = self._get_userconfig('refresh_token')
         else:
-            self.msg.info(self.name, 'Requesting access token...')
+            self.msg.info('Requesting access token...')
 
             params['code'] = self.pin
             params['grant_type'] = 'authorization_code'
@@ -208,7 +208,7 @@ class libshikimori(lib):
         self._emit_signal('userconfig_changed')
 
     def _refresh_user_info(self):
-        self.msg.info(self.name, 'Refreshing user details...')
+        self.msg.info('Refreshing user details...')
 
         data = self._request("GET", self.api_url + "/users/whoami", auth=True)
 
@@ -235,7 +235,7 @@ class libshikimori(lib):
 
     def fetch_list(self):
         self.check_credentials()
-        self.msg.info(self.name, 'Downloading list...')
+        self.msg.info('Downloading list...')
 
         params = {'limit': 5000}
         data = self._request(
@@ -267,17 +267,17 @@ class libshikimori(lib):
 
     def add_show(self, item):
         self.check_credentials()
-        self.msg.info(self.name, "Adding item %s..." % item['title'])
+        self.msg.info("Adding item %s..." % item['title'])
         return self._update_entry(item, "POST")
 
     def update_show(self, item):
         self.check_credentials()
-        self.msg.info(self.name, "Updating item %s..." % item['title'])
+        self.msg.info("Updating item %s..." % item['title'])
         return self._update_entry(item, "PUT")
 
     def delete_show(self, item):
         self.check_credentials()
-        self.msg.info(self.name, "Deleting item %s..." % item['title'])
+        self.msg.info("Deleting item %s..." % item['title'])
 
         data = self._request(
             "DELETE", self.api_url + "/user_rates/{}".format(item['my_id']), auth=True)
@@ -285,7 +285,7 @@ class libshikimori(lib):
     def search(self, criteria, method):
         self.check_credentials()
 
-        self.msg.info(self.name, "Searching for {}...".format(criteria))
+        self.msg.info("Searching for {}...".format(criteria))
         param = {'q': criteria}
         try:
             data = self._request(

--- a/trackma/lib/libvndb.py
+++ b/trackma/lib/libvndb.py
@@ -149,10 +149,10 @@ class libvndb(lib):
         if self.logged_in:
             return True
 
-        self.msg.info(self.name, 'Connecting...')
+        self.msg.info('Connecting...')
         self._connect()
 
-        self.msg.info(self.name, 'Logging in...')
+        self.msg.info('Logging in...')
         (name, data) = self._sendcmd('login',
                                      {'protocol': 1,
                                       'client': 'Trackma',
@@ -177,7 +177,7 @@ class libvndb(lib):
         page = 1
         vns = dict()
         while True:
-            self.msg.info(self.name, 'Downloading list... (%d)' % page)
+            self.msg.info('Downloading list... (%d)' % page)
 
             (name, data) = self._sendcmd('get %s basic (uid = 0)' % self.mediatype,
                                          {'page': page,
@@ -205,7 +205,7 @@ class libvndb(lib):
         # Retrieve scores per pages
         page = 1
         while True:
-            self.msg.info(self.name, 'Downloading votes... (%d)' % page)
+            self.msg.info('Downloading votes... (%d)' % page)
 
             (name, data) = self._sendcmd('get votelist basic (uid = 0)',
                                          {'page': page,
@@ -243,7 +243,7 @@ class libvndb(lib):
         infos = list()
         remaining = [show['id'] for show in itemlist]
         while True:
-            self.msg.info(self.name, 'Requesting details...(%d)' % start)
+            self.msg.info('Requesting details...(%d)' % start)
             end = start + self.pagesize_details
 
             (name, data) = self._sendcmd('get vn basic,details (id = %s)' % repr(remaining[start:end]),
@@ -278,7 +278,7 @@ class libvndb(lib):
 
         # Update status with set vnlist
         if 'my_status' in item:
-            self.msg.info(self.name, 'Updating VN %s (status)...' %
+            self.msg.info('Updating VN %s (status)...' %
                           item['title'])
 
             if self.mediatype == 'wishlist':
@@ -294,7 +294,7 @@ class libvndb(lib):
 
         # Update vote with set votelist
         if 'my_score' in item:
-            self.msg.info(self.name, 'Updating VN %s (vote)...' %
+            self.msg.info('Updating VN %s (vote)...' %
                           item['title'])
 
             if item['my_score'] > 0:
@@ -313,7 +313,7 @@ class libvndb(lib):
     def delete_show(self, item):
         self.check_credentials()
 
-        self.msg.info(self.name, 'Deleting VN %s...' % item['title'])
+        self.msg.info('Deleting VN %s...' % item['title'])
 
         (name, data) = self._sendcmd('set %s %d' %
                                      (self.mediatype, item['id']))
@@ -325,7 +325,7 @@ class libvndb(lib):
         self.check_credentials()
 
         results = list()
-        self.msg.info(self.name, 'Searching for %s...' % criteria)
+        self.msg.info('Searching for %s...' % criteria)
 
         (name, data) = self._sendcmd('get vn basic,details (search ~ "%s")' % criteria,
                                      {'page': 1,
@@ -348,7 +348,7 @@ class libvndb(lib):
         return results
 
     def logout(self):
-        self.msg.info(self.name, 'Disconnecting...')
+        self.msg.info('Disconnecting...')
         self._disconnect()
         self.logged_in = False
 

--- a/trackma/tracker/inotify.py
+++ b/trackma/tracker/inotify.py
@@ -27,15 +27,14 @@ class inotifyTracker(inotifyBase.inotifyBase):
 
     def observe(self, config, watch_dirs):
         # Note that this lib uses bytestrings for filenames and paths.
-        self.msg.info(self.name, 'Using inotify.')
+        self.msg.info('Using inotify.')
 
-        self.msg.debug(self.name, 'Checking if there are open players...')
+        self.msg.debug('Checking if there are open players...')
         opened = self._proc_poll()
         if opened:
             self._proc_open(*opened)
 
-        self.msg.debug(
-            self.name, 'Watching the following paths: ' + ','.join(watch_dirs))
+        self.msg.debug('Watching the following paths: ' + ','.join(watch_dirs))
 
         paths = (path.encode('utf-8') for path in watch_dirs)
         mask = (inotify.constants.IN_OPEN
@@ -81,5 +80,5 @@ class inotifyTracker(inotifyBase.inotifyBase):
                     self.update_show_if_needed(
                         self.last_state, self.last_show_tuple)
         finally:
-            self.msg.info(self.name, 'Tracker has stopped.')
+            self.msg.info('Tracker has stopped.')
             # inotify resource is cleaned-up automatically

--- a/trackma/tracker/inotifyBase.py
+++ b/trackma/tracker/inotifyBase.py
@@ -87,19 +87,17 @@ class inotifyBase(tracker.TrackerBase):
                         with open('/proc/%s/cmdline' % p, 'rb') as f:
                             cmdline = f.read()
                             pname = cmdline.partition(b'\x00')[0]
-                        self.msg.debug(
-                            self.name, 'Playing process: {} {} ({})'.format(p, pname, cmdline))
+                        self.msg.debug('Playing process: {} {} ({})'.format(p, pname, cmdline))
 
                         # Check if it's our process
                         if self.re_players.search(pname):
                             return p, fd
                         else:
-                            self.msg.debug(
-                                self.name, "Not read by player ({})".format(pname))
+                            self.msg.debug("Not read by player ({})".format(pname))
             except OSError:
                 pass
 
-        self.msg.debug(self.name, "Couldn't find playing process.")
+        self.msg.debug("Couldn't find playing process.")
         return None, None
 
     def _closed_handle(self, pid, fd):
@@ -110,7 +108,7 @@ class inotifyBase(tracker.TrackerBase):
         return not os.path.islink(d)
 
     def _proc_open(self, path, name):
-        self.msg.debug(self.name, 'Got OPEN event: {} {}'.format(path, name))
+        self.msg.debug('Got OPEN event: {} {}'.format(path, name))
         pathname = os.path.join(path, name)
 
         pid, fd = self._is_being_played(pathname)
@@ -123,24 +121,23 @@ class inotifyBase(tracker.TrackerBase):
                 (state, show_tuple) = self._get_playing_show(pathname)
             else:
                 (state, show_tuple) = self._get_playing_show(name)
-            self.msg.debug(
-                self.name, "Got status: {} {}".format(state, show_tuple))
+            self.msg.debug("Got status: {} {}".format(state, show_tuple))
             self.update_show_if_needed(state, show_tuple)
         else:
-            self.msg.debug(self.name, "Not played by player, ignoring.")
+            self.msg.debug("Not played by player, ignoring.")
 
     def _proc_close(self, path, name):
-        self.msg.debug(self.name, 'Got CLOSE event: {} {}'.format(path, name))
+        self.msg.debug('Got CLOSE event: {} {}'.format(path, name))
         pathname = os.path.join(path, name)
 
         open_pathname, pid, fd = self.open_file
 
         if pathname != open_pathname:
-            self.msg.debug(self.name, "A different file was closed.")
+            self.msg.debug("A different file was closed.")
             return
 
         if not self._closed_handle(pid, fd):
-            self.msg.debug(self.name, "Our pid hasn't closed the file.")
+            self.msg.debug("Our pid hasn't closed the file.")
             return
 
         self._emit_signal('detected', path, name)

--- a/trackma/tracker/jellyfin.py
+++ b/trackma/tracker/jellyfin.py
@@ -45,7 +45,7 @@ class JellyfinTracker(tracker.TrackerBase):
         super().__init__(messenger, tracker_list, config, watch_dirs, redirections)
 
     def observe(self, config, watch_dirs):
-        self.msg.info(self.name, "Using Jellyfin.")
+        self.msg.info("Using Jellyfin.")
 
         while self.active:
             session_info = self._get_sessions_info()
@@ -53,7 +53,7 @@ class JellyfinTracker(tracker.TrackerBase):
 
             if self.status_log[-1] == ACTIVE or self.status_log[-1] == IDLE:
                 if self.status_log[-1] == IDLE and self.status_log[-2] == NOT_RUNNING:
-                    self.msg.info(self.name, "Reconnected to Jellyfin.")
+                    self.msg.info("Reconnected to Jellyfin.")
                     self.wait_s = config['tracker_update_wait_s']
 
                 try:
@@ -76,10 +76,9 @@ class JellyfinTracker(tracker.TrackerBase):
                         pass
 
             elif self.status_log[-1] == CLAIMED and self.status_log[-2] == CLAIMED:
-                self.msg.warn(
-                    self.name, "Claimed Jellyfin, login in the settings and restart trackma.")
+                self.msg.warn("Claimed Jellyfin, login in the settings and restart trackma.")
             elif self.status_log[-1] == NOT_RUNNING and self.status_log[-2] == NOT_RUNNING:
-                self.msg.warn(self.name, "Jellyfin is not running.")
+                self.msg.warn("Jellyfin is not running.")
 
             del self.status_log[0]
 

--- a/trackma/tracker/kodi.py
+++ b/trackma/tracker/kodi.py
@@ -129,13 +129,13 @@ class KodiTracker(tracker.TrackerBase):
         return info[prop]
 
     def observe(self, config, watch_dirs):
-        self.msg.info(self.name, "Using Kodi.")
+        self.msg.info("Using Kodi.")
 
         while self.active:
             self.status_log.append(self._get_kodi_status())
 
             if self.status_log[-1] == IDLE and self.status_log[-2] == NOT_RUNNING:
-                self.msg.info(self.name, "Reconnected to Kodi.")
+                self.msg.info("Reconnected to Kodi.")
 
             if self.status_log[-1] == ACTIVE:
                 if self.config['kodi_obey_update_wait_s']:
@@ -154,10 +154,9 @@ class KodiTracker(tracker.TrackerBase):
                     self.resume_timer()
 
             elif self.status_log[-1] == AUTH_REQUIRED:
-                self.msg.warn(
-                    self.name, "Authentication needed by Kodi, login in the settings and restart trackma.")
+                self.msg.warn("Authentication needed by Kodi, login in the settings and restart trackma.")
             elif self.status_log[-1] == NOT_RUNNING:
-                self.msg.warn(self.name, "Kodi HTTP Server is not running.")
+                self.msg.warn("Kodi HTTP Server is not running.")
 
             del self.status_log[0]
 

--- a/trackma/tracker/mpris.py
+++ b/trackma/tracker/mpris.py
@@ -38,12 +38,10 @@ class MPRISTracker(tracker.TrackerBase):
             try:
                 sender = self.bus.GetNameOwner(name)
             except GLib.Error:
-                self.msg.warn(
-                    self.name, "Bus was closed before access: {}".format(name))
+                self.msg.warn("Bus was closed before access: {}".format(name))
                 return
 
-            self.msg.info(
-                self.name, "Connecting to MPRIS player: {}".format(name))
+            self.msg.info("Connecting to MPRIS player: {}".format(name))
             try:
                 proxy = self.session.get(name, '/org/mpris/MediaPlayer2')
                 properties = proxy['org.freedesktop.DBus.Properties']
@@ -71,7 +69,7 @@ class MPRISTracker(tracker.TrackerBase):
             except GLib.Error:
                 self._stopped(sender)
         else:
-            self.msg.info(self.name, "Unknown player: {}".format(name))
+            self.msg.info("Unknown player: {}".format(name))
 
     def _get_filename(self, metadata):
         if 'xesam:title' in metadata and len(metadata['xesam:title']) > 5:
@@ -83,7 +81,7 @@ class MPRISTracker(tracker.TrackerBase):
             return None
 
     def _handle_status(self, status, sender):
-        self.msg.debug(self.name, "New playback status: {}".format(status))
+        self.msg.debug("New playback status: {}".format(status))
 
         if status == "Playing":
             self._playing(self.filenames[sender], sender)
@@ -98,22 +96,22 @@ class MPRISTracker(tracker.TrackerBase):
 
     def _playing(self, filename, sender):
         if filename != self.last_filename:
-            self.msg.debug(self.name, "New video: {}".format(filename))
+            self.msg.debug("New video: {}".format(filename))
 
             (state, show_tuple) = self._get_playing_show(filename)
             self.update_show_if_needed(state, show_tuple)
 
-            self.msg.debug(self.name, "New tracker status: {} (previously: {})".format(
+            self.msg.debug("New tracker status: {} (previously: {})".format(
                 state, self.last_state))
 
             # We can override the active player if this player is playing a valid show.
             if not self.active_player or self.last_state == utils.Tracker.PLAYING:
-                self.msg.debug(self.name, "({}) Setting active player: {}".format(
+                self.msg.debug("({}) Setting active player: {}".format(
                     self.last_state, sender))
                 self.active_player = sender
 
                 if not self.timing:
-                    self.msg.debug(self.name, "Starting MPRIS timer.")
+                    self.msg.debug("Starting MPRIS timer.")
                     self.timing = True
 
                     self._pass_timer()
@@ -124,8 +122,7 @@ class MPRISTracker(tracker.TrackerBase):
 
         if sender == self.active_player:
             # Active player got closed!
-            self.msg.debug(
-                self.name, "Clearing active player: {}".format(sender))
+            self.msg.debug("Clearing active player: {}".format(sender))
             self.active_player = None
             self.view_offset = None
 
@@ -167,8 +164,7 @@ class MPRISTracker(tracker.TrackerBase):
                 self._handle_status(status, sender)
 
         else:
-            self.msg.debug(
-                self.name, "Got signal from an inactive player, ignoring.")
+            self.msg.debug("Got signal from an inactive player, ignoring.")
 
     def _new_name(self, name, old, new):
         if name.startswith(MPRISTracker.mpris_base):
@@ -184,7 +180,7 @@ class MPRISTracker(tracker.TrackerBase):
         return self.timing
 
     def observe(self, config, watch_dirs):
-        self.msg.info(self.name, "Using MPRIS.")
+        self.msg.info("Using MPRIS.")
 
         self.re_players = re.compile(config['tracker_process'])
         self.filenames = {}

--- a/trackma/tracker/plex.py
+++ b/trackma/tracker/plex.py
@@ -89,14 +89,14 @@ class PlexTracker(tracker.TrackerBase):
             return None
 
     def observe(self, config, watch_dirs):
-        self.msg.info(self.name, "Using Plex.")
+        self.msg.info("Using Plex.")
 
         while self.active:
             self.status_log.append(self.get_plex_status())
 
             if self.status_log[-1] == ACTIVE or self.status_log[-1] == IDLE:
                 if self.status_log[-1] == IDLE and self.status_log[-2] == NOT_RUNNING:
-                    self.msg.info(self.name, "Reconnected to Plex.")
+                    self.msg.info("Reconnected to Plex.")
 
                 if self.config['plex_obey_update_wait_s']:
                     self.wait_s = config['tracker_update_wait_s']
@@ -132,10 +132,9 @@ class PlexTracker(tracker.TrackerBase):
                     else:
                         pass
             elif self.status_log[-1] == CLAIMED and self.status_log[-2] == CLAIMED:
-                self.msg.warn(
-                    self.name, "Claimed Plex Media Server, login in the settings and restart trackma.")
+                self.msg.warn("Claimed Plex Media Server, login in the settings and restart trackma.")
             elif self.status_log[-1] == NOT_RUNNING and self.status_log[-2] == NOT_RUNNING:
-                self.msg.warn(self.name, "Plex Media Server is not running.")
+                self.msg.warn("Plex Media Server is not running.")
 
             del self.status_log[0]
 

--- a/trackma/tracker/polling.py
+++ b/trackma/tracker/polling.py
@@ -32,8 +32,7 @@ class PollingTracker(tracker.TrackerBase):
                 lsof = subprocess.Popen(
                     ['lsof', '-w', '-n', '-c', ''.join(['/', players, '/']), '-Fn', path], stdout=subprocess.PIPE)
             except OSError:
-                self.msg.warn(
-                    self.name, "Couldn't execute lsof. Disabling tracker.")
+                self.msg.warn("Couldn't execute lsof. Disabling tracker.")
                 self.disable()
                 return None
 
@@ -46,8 +45,7 @@ class PollingTracker(tracker.TrackerBase):
         return None
 
     def observe(self, config, watch_dirs):
-        self.msg.info(
-            self.name, "pyinotify not available; using polling (slow).")
+        self.msg.info("pyinotify not available; using polling (slow).")
         while self.active:
             # This runs the tracker and update the playing show if necessary
             filename = self.get_playing_file(

--- a/trackma/tracker/pyinotify.py
+++ b/trackma/tracker/pyinotify.py
@@ -24,9 +24,9 @@ class pyinotifyTracker(inotifyBase.inotifyBase):
     name = 'Tracker (pyinotify)'
 
     def observe(self, config, watch_dirs):
-        self.msg.info(self.name, 'Using pyinotify.')
+        self.msg.info('Using pyinotify.')
 
-        self.msg.debug(self.name, 'Checking if there are open players...')
+        self.msg.debug('Checking if there are open players...')
         opened = self._proc_poll()
         if opened:
             self._proc_open(*opened)
@@ -77,7 +77,7 @@ class pyinotifyTracker(inotifyBase.inotifyBase):
         handler = EventHandler(parent=self)
         notifier = pyinotify.Notifier(wm, handler)
         for path in watch_dirs:
-            self.msg.debug(self.name, 'Watching directory {}'.format(path))
+            self.msg.debug('Watching directory {}'.format(path))
             wm.add_watch(path, mask, rec=True, auto_add=True)
 
         try:
@@ -96,10 +96,10 @@ class pyinotifyTracker(inotifyBase.inotifyBase):
                     else:
                         timeout = 1000  # Check each second for counting
                 elif self.active:
-                    self.msg.debug(self.name, "Sending last state {} {}".format(
+                    self.msg.debug("Sending last state {} {}".format(
                         self.last_state, self.last_show_tuple))
                     self.update_show_if_needed(
                         self.last_state, self.last_show_tuple)
         finally:
             notifier.stop()
-            self.msg.info(self.name, 'Tracker has stopped.')
+            self.msg.info('Tracker has stopped.')

--- a/trackma/tracker/tracker.py
+++ b/trackma/tracker/tracker.py
@@ -46,7 +46,7 @@ class TrackerBase(object):
     }
 
     def __init__(self, messenger, tracker_list, config, watch_dirs, redirections=None):
-        self.msg = messenger
+        self.msg = messenger.with_classname(self.name)
         self.msg.info(self.name, 'Initializing...')
 
         self.list = tracker_list
@@ -71,7 +71,7 @@ class TrackerBase(object):
 
     def set_message_handler(self, message_handler):
         """Changes the message handler function on the fly."""
-        self.msg = message_handler
+        self.msg = message_handler.with_classname(self.name)
 
     def disable(self):
         self.msg.info(self.name, 'Unloading...')

--- a/trackma/tracker/tracker.py
+++ b/trackma/tracker/tracker.py
@@ -47,7 +47,7 @@ class TrackerBase(object):
 
     def __init__(self, messenger, tracker_list, config, watch_dirs, redirections=None):
         self.msg = messenger.with_classname(self.name)
-        self.msg.info(self.name, 'Initializing...')
+        self.msg.info('Initializing...')
 
         self.list = tracker_list
         self.config = config
@@ -66,7 +66,7 @@ class TrackerBase(object):
         tracker_t = threading.Thread(target=self.observe, args=tracker_args)
         tracker_t.daemon = True
 
-        self.msg.debug(self.name, 'Enabling tracker...')
+        self.msg.debug('Enabling tracker...')
         tracker_t.start()
 
     def set_message_handler(self, message_handler):
@@ -74,7 +74,7 @@ class TrackerBase(object):
         self.msg = message_handler.with_classname(self.name)
 
     def disable(self):
-        self.msg.info(self.name, 'Unloading...')
+        self.msg.info('Unloading...')
         self.active = False
 
     def update_list(self, tracker_list):
@@ -126,7 +126,7 @@ class TrackerBase(object):
                 def action(): return self._emit_signal('unrecognised', show, episode)
 
             if self.config['tracker_update_close']:
-                self.msg.info(self.name, 'Waiting for the player to close.')
+                self.msg.info('Waiting for the player to close.')
                 self.last_close_queue = action
             elif action:
                 action()
@@ -187,30 +187,27 @@ class TrackerBase(object):
                 expected_next_ep = show['my_progress'] + 1
                 if self.config['tracker_ignore_not_next'] and episode != expected_next_ep:
                     self.msg.warn(
-                        self.name,
                         'Not playing the next episode of {} (expected: {}, found: {}). Ignoring.'
                             .format(show['title'], expected_next_ep, episode),
                     )
                     self._ignore_current()
                     return
                 if episode == show['my_progress']:
-                    self.msg.warn(
-                        self.name, 'Playing the current episode of %s. Ignoring.' % show['title'])
+                    self.msg.warn('Playing the current episode of %s. Ignoring.' % show['title'])
                     self._ignore_current()
                     return
                 if episode < 1 or (show['total'] and episode > show['total']):
-                    self.msg.warn(
-                        self.name, 'Playing an invalid episode of %s. Ignoring.' % show['title'])
+                    self.msg.warn('Playing an invalid episode of %s. Ignoring.' % show['title'])
                     self._ignore_current()
                     return
 
             # Start our countdown
             (show, episode) = show_tuple
             if state == utils.Tracker.PLAYING:
-                self.msg.info(self.name, 'Will update %s %d' %
+                self.msg.info('Will update %s %d' %
                               (show['title'], episode))
             elif state == utils.Tracker.NOT_FOUND:
-                self.msg.info(self.name, 'Will add %s %d' %
+                self.msg.info('Will add %s %d' %
                               (show['title'], episode))
 
             self._update_show(state, show_tuple)
@@ -221,14 +218,12 @@ class TrackerBase(object):
             if state == utils.Tracker.NOVIDEO:  # No video is playing
                 # Video didn't get to update phase before it was closed
                 if self.last_state == utils.Tracker.PLAYING and not self.last_updated:
-                    self.msg.info(
-                        self.name, 'Player was closed before update.')
+                    self.msg.info('Player was closed before update.')
             # There's a new video playing but the regex didn't recognize the format
             elif state == utils.Tracker.UNRECOGNIZED:
-                self.msg.warn(
-                    self.name, 'Found video but the file name format couldn\'t be recognized.')
+                self.msg.warn('Found video but the file name format couldn\'t be recognized.')
             elif state == utils.Tracker.NOT_FOUND:  # There's a new video playing but an associated show wasn't found
-                self.msg.warn(self.name, 'Found player but show not in list.')
+                self.msg.warn('Found player but show not in list.')
 
             self.last_show_tuple = None
             self.last_updated = False
@@ -243,7 +238,7 @@ class TrackerBase(object):
             return (utils.Tracker.NOVIDEO, None)
 
         if filename:
-            self.msg.debug(self.name, "Guessing filename: {}".format(filename))
+            self.msg.debug("Guessing filename: {}".format(filename))
 
             # Trim out watch dir
             if os.path.isabs(filename):
@@ -256,7 +251,7 @@ class TrackerBase(object):
 
             if filename == self.last_filename:
                 # It's the exact same filename, there's no need to do the processing again
-                self.msg.debug(self.name, "Same filename as before. Skipping.")
+                self.msg.debug("Same filename as before. Skipping.")
                 return (self.last_state, self.last_show_tuple)
 
             self.last_filename = filename
@@ -270,14 +265,14 @@ class TrackerBase(object):
                 return (utils.Tracker.UNRECOGNIZED, None)
 
             playing_show = utils.guess_show(show_title, self.list)
-            self.msg.debug(self.name, "Show guess: {}: {} ({})".format(
+            self.msg.debug("Show guess: {}: {} ({})".format(
                 show_title, playing_show, show_ep))
 
             if playing_show:
                 (redirected_show, redirected_ep) = utils.redirect_show(
                     (playing_show, show_ep), self.redirections, self.list)
                 if (redirected_show, redirected_ep) != (playing_show, show_ep):
-                    self.msg.debug(self.name, "Redirected to: {} ({})".format(redirected_show, redirected_ep))
+                    self.msg.debug("Redirected to: {} ({})".format(redirected_show, redirected_ep))
                     (playing_show, show_ep) = (redirected_show, redirected_ep)
 
                 return (utils.Tracker.PLAYING, (playing_show, show_ep))

--- a/trackma/tracker/win32.py
+++ b/trackma/tracker/win32.py
@@ -64,7 +64,7 @@ class Win32Tracker(tracker.TrackerBase):
         return False
 
     def observe(self, config, watch_dirs):
-        self.msg.info(self.name, "Using Win32.")
+        self.msg.info("Using Win32.")
 
         while self.active:
             # This runs the tracker and update the playing show if necessary


### PR DESCRIPTION
I changed the Messenger class to hold a internal class name. Every other class that uses the messenger (`Engine`, `Data`, `Lib` and `TrackerBase`), will instance the messenger class with their `self.name` only once, and every call to this instance, will optionally re-use the given name.

I say optionally, because `debug`, `info`, `warn` and `exception` can still receive a class name, so Hooks continue exactly the same: that's not a breaking change.

I searched and removed `self.name` from every `debug`, `info`, `warn` and `exception` call in the code base. As a bonus, almost every two-line call was inlined.

```
-     self.msg.warn(
-         self.name, "Unknown operation in queue (%s), skipping..." % repr(operation))
+     self.msg.warn("Unknown operation in queue (%s), skipping..." % repr(operation))
```

The code is now simpler, and `self.name` is only used twice in each of those classes.

I revised the changes thrice, but feel free review yourself :smiley: 