### PR TITLE
[GTK] fix Gdk ImportError

### DIFF
--- a/trackma/ui/gtk/window.py
+++ b/trackma/ui/gtk/window.py
@@ -19,7 +19,11 @@ import subprocess
 import sys
 import threading
 
-from gi.repository import GLib, Gdk, Gio, Gtk
+from gi.repository import GLib, Gio, Gtk
+
+# When Gdk is loaded before Gtk, the program crashes:
+# "Requiring namespace 'Gdk' version '3.0', but '4.0' is already loaded"
+from gi.repository import Gdk
 
 from trackma import messenger
 from trackma import utils


### PR DESCRIPTION
This is a very strange bug. When Gdk is loaded before Gtk, the program crashes with:

```
ImportError: Requiring namespace 'Gdk' version '3.0', but '4.0' is already loaded
```

This is easy to fix, but note that this bug was introduced when formatting the code. I did my best to make this as explicit as possible in the code itself, so if this bug is introduced again, it should be more straightforward to fix. I also tested `ypaf`, `black` and `autopep8`, and none of those removed my "fix" yet.

It would be great if someone could reproduce the bug before merging the PR, to be sure this isn't something only I am experiencing.