### PR TITLE
fix hook episode_missing_ani-cli.py episode loop

### DIFF
--- a/hooks/episode_missing_ani-cli.py
+++ b/hooks/episode_missing_ani-cli.py
@@ -4,22 +4,31 @@
 
  When an episode is not found, it executes 'ani-cli' to find and
  watch it via streaming automatically!
+ 
+ It's highly recommended to also have 'rofi' installed, because it's used as a
+ fallback menu, where you can select manually the correct season/special/movie
+ and even continue using ani-cli after the episode ends.
+
+ Last tested with ani-cli version 4.2.0
 """
 
 import shutil
-from subprocess import Popen, PIPE, DEVNULL 
+from subprocess import Popen, DEVNULL
 
 
 # Executed when trying to watch an episode that doesn't exist in your library
 def episode_missing(engine, show, episode):
-    anicli = shutil.which("ani-cli")  # find 'ani-cli' executable
+    anicli = shutil.which("ani-cli") # find 'ani-cli' executable
     if anicli:
         query = show["title"].strip()
-        args = [anicli, "-q", "best", "-a", str(episode), query]
+        args = [anicli, "-q", "best", "-e", str(episode), query]
+        if not shutil.which("rofi"):
+            # if you don't have 'rofi' installed,
+            # add '-S 1' to select the first show automatically
+            args[1:1] = ["-S", "1"]
         cmd = " ".join(args[:-1]) + f" '{query}'"
-        engine.msg.info("episode_missing", cmd)  # Show the command used
-        process = Popen(args, stdin=PIPE, stdout=DEVNULL, stderr=DEVNULL, text=True)
-        process.communicate(input="q")
+        engine.msg.info("episode_missing", cmd) # Show the command used
+        Popen(args, stdin=DEVNULL, stdout=DEVNULL, stderr=DEVNULL)
     else:
         engine.msg.info("episode_missing", "ani-cli was not found")
 
@@ -29,4 +38,4 @@ if __name__ == "__main__":
         class Messenger:
             info = print
         msg = Messenger()
-    episode_missing(MockEngine(), {"title": "Jiandao Di Yi Xian"}, 9)
+    episode_missing(MockEngine(), {"title": "One Piece"}, 1)

--- a/hooks/episode_missing_ani-cli.py
+++ b/hooks/episode_missing_ani-cli.py
@@ -7,18 +7,26 @@
 """
 
 import shutil
-from trackma import utils
+from subprocess import Popen, PIPE, DEVNULL 
 
 
 # Executed when trying to watch an episode that doesn't exist in your library
 def episode_missing(engine, show, episode):
-
-    query = show["title"].strip()
     anicli = shutil.which("ani-cli")  # find 'ani-cli' executable
     if anicli:
+        query = show["title"].strip()
         args = [anicli, "-q", "best", "-a", str(episode), query]
         cmd = " ".join(args[:-1]) + f" '{query}'"
         engine.msg.info("episode_missing", cmd)  # Show the command used
-        utils.spawn_process(args)
+        process = Popen(args, stdin=PIPE, stdout=DEVNULL, stderr=DEVNULL, text=True)
+        process.communicate(input="q")
     else:
         engine.msg.info("episode_missing", "ani-cli was not found")
+
+# You can run this file directly to test it
+if __name__ == "__main__":
+    class MockEngine:
+        class Messenger:
+            info = print
+        msg = Messenger()
+    episode_missing(MockEngine(), {"title": "Jiandao Di Yi Xian"}, 9)


### PR DESCRIPTION
~~Note: the hook is now blocking.~~
Also, i guess `utils.spawn_process` could be deprecated. The python team had quite the time to stabilize the subprocess module, maybe the zombie processes happening before doesn't happen anymore. The `os` module used is quite hard to understand.