### PR TITLE
Set desktop file name for Wayland icon

### DIFF
--- a/trackma/ui/qt/__init__.py
+++ b/trackma/ui/qt/__init__.py
@@ -73,7 +73,7 @@ def main(force_qt4=False):
 
     app = QApplication(sys.argv)
     app.setApplicationName("trackma")
-    app.setDesktopFileName("Trackma-qt")
+    app.setDesktopFileName("trackma-qt")
     if os.name == "nt":
         import ctypes
         myappid = 'trackma' + utils.VERSION

--- a/trackma/ui/qt/__init__.py
+++ b/trackma/ui/qt/__init__.py
@@ -73,7 +73,7 @@ def main(force_qt4=False):
 
     app = QApplication(sys.argv)
     app.setApplicationName("trackma")
-    app.setDesktopFileName("trackma")
+    app.setDesktopFileName("Trackma-qt")
     if os.name == "nt":
         import ctypes
         myappid = 'trackma' + utils.VERSION

--- a/trackma/ui/qt/mainwindow.py
+++ b/trackma/ui/qt/mainwindow.py
@@ -67,6 +67,7 @@ class MainWindow(QMainWindow):
         self.config = utils.parse_config(self.configfile, utils.qt_defaults)
 
         # Build UI
+        QtGui.QGuiApplication.setDesktopFileName("Trackma-qt")
         if os.name != "nt":
             QApplication.setWindowIcon(QtGui.QIcon(utils.DATADIR + '/icon.png'))
         else:

--- a/trackma/ui/qt/mainwindow.py
+++ b/trackma/ui/qt/mainwindow.py
@@ -67,7 +67,6 @@ class MainWindow(QMainWindow):
         self.config = utils.parse_config(self.configfile, utils.qt_defaults)
 
         # Build UI
-        QtGui.QGuiApplication.setDesktopFileName("Trackma-qt")
         if os.name != "nt":
             QApplication.setWindowIcon(QtGui.QIcon(utils.DATADIR + '/icon.png'))
         else:


### PR DESCRIPTION
I found this solution to Wayland not showing the icon for PyQt applications thanks to the KDE guidelines [here](https://community.kde.org/Guidelines_and_HOWTOs/Wayland_Porting_Notes#Application_Icon). 

I was having the same issue of the Wayland yellow and white icon showing in the application's title bar and in the task manager on the panel with some PyQt6 applications I made. When I added this line, it fixed the icon issue for both locations with my applications, but for some reason it's not fixing it for Trackma's title bar icon. Still, I figured this was better than nothing, as it fixes it for the task manager on the panel.

Edit:  I hadn't realized setDesktopFileName was already called in \_\_init\_\_.py. The second commit uses that original call instead of calling the function again. Still having the same problem of it not fixing the title bar in KDE Wayland, though.