### PR TITLE
list shows in json format

### DIFF
--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -991,7 +991,7 @@ class Trackma_cmd(command.Cmd):
             j = {
                 "title": title_str,
                 "current_episode": episode_str_current,
-                "final_episode": episode_str_last,
+                "total_episodes": episode_str_last,
                 "score": score
             }
 

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -991,7 +991,7 @@ class Trackma_cmd(command.Cmd):
             # Check if show is airing and get estimated aired episode
             if show['status'] == utils.Status.AIRING:
                 estimate = utils.estimate_aired_episodes(show)
-                j["estimated_aired_episode"] = estimate
+                j["estimated_aired_episode"] = "{0}".format(estimate)
 
             print(json.dumps(j))
 

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -75,7 +75,6 @@ class Trackma_cmd(command.Cmd):
         'sort':         1,
         'mediatype':    (0, 1),
         'info':         1,
-        'name':         1,
         'search':       1,
         'list_json':    (0, 1),
         'add':          1,
@@ -382,21 +381,6 @@ class Trackma_cmd(command.Cmd):
                 return
 
         self._make_list_json(self.sortedlist)
-
-    def do_name(self, args):
-        """
-        Print title name for given index.
-
-        :param show Show index.
-        :usage name <index>
-        """
-        try:
-            show = self._get_show(args[0])
-        except utils.TrackmaError as e:
-            self.display_error(e)
-            return
-
-        print(show['title'])
 
     def do_info(self, args):
         """

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -362,6 +362,13 @@ class Trackma_cmd(command.Cmd):
         # Show the list in memory
         self._make_list(self.sortedlist)
 
+    def do_list_raw(self, args):
+        """
+        Similar to list except remove formatting.
+        : name list_raw
+        """
+        self._make_list_raw(self.sortedlist)
+
     def do_info(self, args):
         """
         Gets detailed information about a local show.
@@ -945,6 +952,26 @@ class Trackma_cmd(command.Cmd):
         print('%d results' % len(showlist))
         print()
 
+    def _make_list_raw(self, showlist):
+        """
+        Helper function for printing a non-formatted show list
+        """
+        altnames = self.engine.altnames()
+
+        # List shows
+        for index, show in showlist:
+            if self.engine.mediainfo['has_progress']:
+                episodes_str = "{0}\t{1}".format(
+                    show['my_progress'], show['total'] or '?')
+            else:
+                episodes_str = "-"
+
+            # Get title (and alt. title) and if need be, truncate it
+            title_str = show['title']
+            if altnames.get(show['id']):
+                title_str += " [{}]".format(altnames.get(show['id']))
+
+            print(index,title_str, episodes_str,show['my_score'],sep='\t')
 
 class Trackma_accounts(AccountManager):
     def _get_id(self, index):

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -979,10 +979,8 @@ class Trackma_cmd(command.Cmd):
                 episode_str_current = "{0}".format(show['my_progress'] or '0')
                 episode_str_last = "{0}".format(show['total'] or '?')
 
-            # get title (and alt. title) and if need be, truncate it
+            # get title
             title_str = show['title']
-            if altnames.get(show['id']):
-                title_str += " [{}]".format(altnames.get(show['id']))
 
             # ensure score is string; anilist can have string scores such as stars or smiles
             score = "{0}".format(show['my_score'])

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -969,41 +969,29 @@ class Trackma_cmd(command.Cmd):
         """
         helper function for printing a json formatted show list
         """
-        altnames = self.engine.altnames()
 
-        episode_str_current = ""
-        episode_str_last = ""
         # list shows
         for index, show in showlist:
             if self.engine.mediainfo['has_progress']:
                 episode_str_current = "{0}".format(show['my_progress'] or '0')
                 episode_str_last = "{0}".format(show['total'] or '?')
 
-            # get title
-            title_str = show['title']
-
             # ensure score is string; anilist can have string scores such as stars or smiles
             score = "{0}".format(show['my_score'])
 
             # json dictionary
             j = {
-                "title": title_str,
+                "title": show['title'],
                 "current_episode": episode_str_current,
                 "total_episodes": episode_str_last,
                 "score": score,
-                "airing_status": False,
-                "behind_status": False
+                "status": show['status'].value
             }
 
-            # Check if show is airing and if user is behind
+            # Check if show is airing and get estimated aired episode
             if show['status'] == utils.Status.AIRING:
                 estimate = utils.estimate_aired_episodes(show)
-                if estimate and show['my_progress'] < estimate:
-                    # User is behind the (estimated) aired episode
-                    j["airing_status"] = True;
-                    j["behind_status"] = True;
-                else:
-                    j["airing_status"] = True;
+                j["estimated_aired_episode"] = estimate
 
             print(json.dumps(j))
 

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -990,19 +990,20 @@ class Trackma_cmd(command.Cmd):
                 "title": title_str,
                 "current_episode": episode_str_current,
                 "total_episodes": episode_str_last,
-                "score": score
+                "score": score,
+                "airing_status": False,
+                "behind_status": False
             }
 
-            # Color title according to status
+            # Check if show is airing and if user is behind
             if show['status'] == utils.Status.AIRING:
                 estimate = utils.estimate_aired_episodes(show)
                 if estimate and show['my_progress'] < estimate:
                     # User is behind the (estimated) aired episode
-                    j["color"] = _COLOR_BEHIND
+                    j["airing_status"] = True;
+                    j["behind_status"] = True;
                 else:
-                    j["color"] = _COLOR_AIRING
-            else:
-                j["color"] = _COLOR_RESET
+                    j["airing_status"] = True;
 
             print(json.dumps(j))
 

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -993,6 +993,9 @@ class Trackma_cmd(command.Cmd):
                 estimate = utils.estimate_aired_episodes(show)
                 j["estimated_aired_episode"] = "{0}".format(estimate)
 
+            # cover image url
+            j["image"] = show['image']
+
             print(json.dumps(j))
 
 class Trackma_accounts(AccountManager):

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -74,6 +74,7 @@ class Trackma_cmd(command.Cmd):
         'sort':         1,
         'mediatype':    (0, 1),
         'info':         1,
+        'name':         1,
         'search':       1,
         'add':          1,
         'del':          1,
@@ -368,6 +369,22 @@ class Trackma_cmd(command.Cmd):
         : name list_raw
         """
         self._make_list_raw(self.sortedlist)
+
+    def do_name(self, args):
+        """
+        Print title name for given index.
+
+        :param show Show index.
+        :usage name <index>
+        """
+        try:
+            show = self._get_show(args[0])
+            details = self.engine.get_show_details(show)
+        except utils.TrackmaError as e:
+            self.display_error(e)
+            return
+
+        print(show['title'])
 
     def do_info(self, args):
         """


### PR DESCRIPTION
For issue https://github.com/z411/trackma/issues/660
If you merge this PR, please squash and merge.

```
$ trackma help
...
     list|ls <>            Lists all shows available in the local list.
   list_json <>            Print list of shows in json format.
...
```
Example of `trackma list_json` (it defaults to watching list)
```json
{"title": "Ars no Kyojuu", "current_episode": "2", "total_episodes": "12", "score": "0", "status": "Ongoing", "estimated_aired_episode": "2", "image": "https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx155089-I5zYFNvWua57.png"}
{"title": "Blue Lock", "current_episode": "14", "total_episodes": "24", "score": "5.5", "status": "Ongoing", "estimated_aired_episode": "14", "image": "https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx137822-4dVWMSHLpGf8.png"}
{"title": "Buddy Daddies", "current_episode": "2", "total_episodes": "13", "score": "0", "status": "Ongoing", "estimated_aired_episode": "2", "image": "https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx155907-gR7aRwVHwrjc.jpg"}
{"title": "Bungou Stray Dogs 4th Season", "current_episode": "2", "total_episodes": "13", "score": "0", "status": "Ongoing", "estimated_aired_episode": "2", "image": "https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx141249-8tjavEDHmLoT.jpg"}
{"title": "Flying Witch", "current_episode": "12", "total_episodes": "12", "score": "0", "status": "Finished", "image": "https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx21284-vQcCLIWt1o5O.png"}
```
Then it also can accept list status, `trackma list_json paused`:
```json
{"title": "Casshern Sins", "current_episode": "15", "total_episodes": "24", "score": "6", "status": "Finished", "image": "https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx4981-V6MbMiJUqdvP.jpg"}
{"title": "Chi's Sweet Home: Atarashii Ouchi", "current_episode": "63", "total_episodes": "104", "score": "0", "status": "Finished", "image": "https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx6024-eYiQMRfPfWiF.jpg"}
{"title": "Joshiraku", "current_episode": "1", "total_episodes": "13", "score": "0", "status": "Finished", "image": "https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx12679-0zlvLP7KyxjH.png"}
{"title": "Karakai Jouzu no Takagi-san 2", "current_episode": "7", "total_episodes": "12", "score": "5", "status": "Finished", "image": "https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx107068-KJq0eFP0GTjL.jpg"}
```
I believe `trackma -a` should work. I tested with `trackma -a 2 list_json` and it asks me to select account first, before listing anything.

In bash scripts, `jq` works as expected. Here is a more complicated command:
```bash
trackma list_json | jq -jr '.title, "|", .current_episode, "|", .total_episodes, "|", .score, "|", .status, "|",.estimated_aired_episode, "\n"'
```
```
Ars no Kyojuu|2|12|0|Ongoing|2
Blue Lock|13|24|5.5|Ongoing|14
Buddy Daddies|2|13|0|Ongoing|2
Bungou Stray Dogs 4th Season|2|13|0|Ongoing|2
Flying Witch|9|12|0|Finished|null
```