### PR TITLE
GTK: change "Play episode" menu aesthetic

### DIFF
--- a/trackma/ui/gtk/mainview.py
+++ b/trackma/ui/gtk/mainview.py
@@ -755,9 +755,9 @@ class NotebookPage(Gtk.ScrolledWindow):
             mb_playep = Gtk.CheckMenuItem(str(i))
             if i == next_ep:
                 mb_playep.set_label(str(i) + " - Next")
-                mb_playep.set_margin_left(10)
                 menu_eps.set_focus_child(mb_playep)
-            mb_playep.set_inconsistent(i < next_ep)
+            if i >= next_ep:
+                mb_playep.set_margin_left(10)
             mb_playep.set_active(i in library_episodes)
             mb_playep.set_draw_as_radio(True)
             mb_playep.connect("activate",


### PR DESCRIPTION
This continues the effort in #616, althrough, a simple one. 
I tested some designs in practice for some weeks, and ended with this, which is actually the same as the one i showed in https://github.com/z411/trackma/pull/616#discussion_r895049777.

## Currently: 
![2023-01-13_12-00](https://user-images.githubusercontent.com/62220318/212361878-af5c17e0-1089-4803-adfe-fbe54bc563c7.png)

## The PR:
![2023-01-13_12-02](https://user-images.githubusercontent.com/62220318/212361950-34ad7ae1-a2e7-4bb9-afbd-e0f68c715753.png)

It's simpler, because the "markings" now only convey a single piece of information: if the episode is available in the library or not; and, the information about being already watched or not, is still conveyed by the mere positioning of the numbers. This bring a more intuitive feel to the menu, as of before, a new user would probably take quite a while until they understand the meaning of the markings.