### PR TITLE
kitsu: Try multiple keys for image urls

### DIFF
--- a/trackma/lib/libkitsu.py
+++ b/trackma/lib/libkitsu.py
@@ -555,15 +555,12 @@ class libkitsu(lib):
         info = utils.show()
         attr = media['attributes']
 
-        # print(json.dumps(media, indent=2))
-        # raise NotImplementedError
-
         if media['type'] == 'anime':
             total = attr['episodeCount']
         elif media['type'] == 'manga':
             total = attr['chapterCount']
         elif media['type'] == 'drama':
-            total = attr['episodeCount']  # TODO Unconfirmed
+            total = attr['episodeCount']
 
         poster_image = attr.get('posterImage', {})
         image = utils.get_any(poster_image, PosterImageKey.SMALL, PosterImageKey.MEDIUM, PosterImageKey.LARGE, PosterImageKey.ORIGINAL)

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -250,6 +250,15 @@ def is_media(filename):
     return os.path.splitext(filename)[1] in EXTENSIONS
 
 
+def get_any(dict_, *keys, default=None):
+    """Get the first key present on a dict."""
+    for key in keys:
+        value = dict_.get(key, Ellipsis)
+        if value is not Ellipsis:
+            return value
+    return default
+
+
 def regex_find_videos(subdirectory=''):
     if subdirectory:
         path = os.path.expanduser(subdirectory)


### PR DESCRIPTION
See title. Addresses the first part of #665 but does not do anything about the URLs only being cacheable for a limited amount of time. That will need separate logic.

Edit: I should mention this is untested.