### PR TITLE
New syntax to CLI "play" command and "watch_continuously" config

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -983,6 +983,38 @@ class Engine:
         args.extend(filenames)
         return args
 
+    def parse_episode_range(self, show, raw_range: str) -> Iterable[int]:
+        """
+        TODO: add documentation
+        """
+        def parse_num(num_str):
+            if num_str.startswith("#"):
+                return int(num_str.lstrip("#"))
+            else:
+                return show["my_progress"] + int(num_str)
+
+        # convert bare "N" to "-N" and "" to "-"
+        if "-" not in raw_range and not raw_range.startswith("#"):
+            raw_range = "-" + raw_range
+
+        # bare "#N"
+        if "-" not in raw_range:
+            first_ep = int(raw_range.lstrip("#"))
+            if not first_ep:
+                raise utils.EngineError("0 is a invalid episode number")
+            ep_iter = (first_ep, )
+        else:
+            left, right = raw_range.split("-")
+            # a left-open range always expand to 1
+            left = parse_num(left or "1")
+            if not left:
+                raise utils.EngineError("0 is a invalid episode number")
+            if right:
+                ep_iter = range(left, 1 + parse_num(right))
+            else:
+                ep_iter = itertools.count(left)
+        return ep_iter
+
     def undoall(self):
         """Clears the data handler queue and discards any unsynced change."""
         return self.data_handler.queue_clear()

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -993,18 +993,23 @@ class Engine:
         Parse a string into a iterable of episode numbers, acording to a custom syntax.
         """
         def parse_num(num_str):
-            if num_str.startswith("#"):
-                return int(num_str.lstrip("#"))
+            if num_str.startswith("n"):
+                return int(num_str.lstrip("n")) + show["my_progress"]
             else:
-                return show["my_progress"] + int(num_str)
+                return int(num_str)
 
-        # convert bare "N" to "-N" and "" to "-"
-        if "-" not in raw_range and not raw_range.startswith("#"):
+        if not raw_range:
+            raw_range = "n1-" if self.config['watch_continuously'] else "-n1"
+        elif raw_range == "n0":
+            raw_range = "n0-n0"
+
+        # convert relative "nX" to "-nX"
+        if "-" not in raw_range and raw_range.startswith("n"):
             raw_range = "-" + raw_range
 
-        # bare "#N"
+        # absolute "X"
         if "-" not in raw_range:
-            first = int(raw_range.lstrip("#"))
+            first = int(raw_range)
             
             if self.config['watch_continuously']:
                 ep_iter = itertools.count(first)
@@ -1012,8 +1017,8 @@ class Engine:
                 ep_iter = (first, )
         else:
             first, last = raw_range.split("-")
-            # a left-open range always expand to 1
-            first = parse_num(first or "1")
+            # a left-open range always expand to n1
+            first = parse_num(first or "n1")
 
             if last:
                 ep_iter = range(first, 1 + parse_num(last))

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -990,7 +990,7 @@ class Engine:
 
     def parse_episode_range(self, show, raw_range: str) -> Iterable[int]:
         """
-        TODO: add documentation
+        Parse a string into a iterable of episode numbers, acording to a custom syntax.
         """
         def parse_num(num_str):
             if num_str.startswith("#"):

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -503,11 +503,26 @@ class Trackma_cmd(command.Cmd):
 
     def do_play(self, args):
         """
-        Starts the media player with the specified episode number (next if unspecified).
+        Starts the media player with the specified episode range.
+        Examples of useful episode ranges: '', '1', '3', '#3', '#3-', '-#6'
+        _
+        Episode range syntax: 'X', 'X-Y', 'X-', '-X'.
+        'X' is relative to the last seen ep:       '1'  is the next ep unwatched.
+        '#X' is absolute ep number:                '#2' is the second ep.
+        'X-' will open 'X' and every ep after:     '#3-' start ep 3 onwards.
+        'X-Y' will open 'X' until 'Y' (inclusive): '#2-#6' ep 2, until ep 6.
+        Range starting with '-' will begin at '1': '-#6' last ep, until ep 6.
+        _
+        For convenience, some conversions are made:
+        '' -> '-' -> '1-'    - continue watching onwards
+        '4' -> '-4' -> '1-4' - watch next 4 episodes
+        If "watch_continuously" config is "true":
+        '#6' -> '#6-'        - play episode 6 onwards
 
         :param show Episode index or title.
-        :optparam ep Episode number or range. TODO: include syntax help
-        :usage play <show index or title> [episode number]
+        :optparam ep Episode range. See syntax above.
+
+        :usage play <show index or title> [episode range]
         """
         try:
             show = self._get_show(args[0])

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -506,21 +506,19 @@ class Trackma_cmd(command.Cmd):
         Starts the media player with the specified episode number (next if unspecified).
 
         :param show Episode index or title.
-        :optparam ep Episode number. Assume next if not specified.
+        :optparam ep Episode number or range. TODO: include syntax help
         :usage play <show index or title> [episode number]
         """
         try:
-            episode = 0
             show = self._get_show(args[0])
 
-            # If the user specified an episode, play it
+            # If the user specified an episode range, play it
             # otherwise play the next episode not watched yet
-            if len(args) > 1:
-                episode = args[1]
-
-            args = self.engine.play_episode(show, episode)
+            raw_range = args[1] if len(args) > 1 else ""
+            ep_iter = self.engine.parse_episode_range(show, raw_range)
+            args = self.engine.play_episode(show, ep_iter)
             utils.spawn_process(args)
-        except utils.TrackmaError as e:
+        except (utils.TrackmaError, ValueError) as e:
             self.display_error(e)
 
     def do_openfolder(self, args):

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -504,20 +504,24 @@ class Trackma_cmd(command.Cmd):
     def do_play(self, args):
         """
         Starts the media player with the specified episode range.
-        Examples of useful episode ranges: '', '1', '3', '#3', '#3-', '-#6'
+        Also, check the "watch_continuously" config option.
+        Examples of useful episode ranges: '', '-', 'n1', 'n3', '3', '3-', '-6'
         _
         Episode range syntax: 'X', 'X-Y', 'X-', '-X'.
-        'X' is relative to the last seen ep:       '1'  is the next ep unwatched.
-        '#X' is absolute ep number:                '#2' is the second ep.
-        'X-' will open 'X' and every ep after:     '#3-' start ep 3 onwards.
-        'X-Y' will open 'X' until 'Y' (inclusive): '#2-#6' ep 2, until ep 6.
-        Range starting with '-' will begin at '1': '-#6' last ep, until ep 6.
+        'X'   is absolute ep number:               '2'  is the second ep.
+        'nX'  is relative to the last seen ep:     'n1' is the next ep unwatched.
+        'X-Y' will open 'X' until 'Y' (inclusive): '2-6' ep 2, until ep 6.
+        'X-'  will open 'X' and every ep after:    '3-' start ep 3 onwards.
+        '-X'  will begin at 'n1':                  '-6' last ep, until ep 6.
         _
         For convenience, some conversions are made:
-        '' -> '-' -> '1-'    - continue watching onwards
-        '4' -> '-4' -> '1-4' - watch next 4 episodes
-        If "watch_continuously" config is "true":
-        '#6' -> '#6-'        - play episode 6 onwards
+        '-'  -> 'n1-'            - continue watching onwards
+        ''   -> '-n1' -> 'n1-n1' - watch next episode
+        'n4' -> '-n4' -> 'n1-n4' - watch next 4 episodes
+        '3'  -> '3-3'            - watch episode 3
+        If "watch_continuously" config is "true", this changes:
+        '' -> 'n1-'              - continue watching onwards
+        '6' -> '6-'              - play episode 6 onwards
 
         :param show Episode index or title.
         :optparam ep Episode range. See syntax above.

--- a/trackma/ui/curses.py
+++ b/trackma/ui/curses.py
@@ -357,12 +357,8 @@ class Trackma_urwid:
                      self.update_request, show['my_progress']+1)
 
     def do_play(self):
-        item = self._get_selected_item()
-        if item:
-            show = self.engine.get_show_info(item.showid)
-            # TODO: use the CLI range syntax
-            self.ask('[Play] Episode # to play: ',
-                     self.play_request, show['my_progress']+1)
+        if self._get_selected_item():
+            self.ask('[Play] Episode range to play (CLI syntax): ', self.play_request, "")
 
     def do_openfolder(self):
         item = self._get_selected_item()
@@ -415,7 +411,7 @@ class Trackma_urwid:
         helptext += "https://github.com/z411/trackma\n\n"
         helptext += "This program is licensed under the GPLv3,\nfor more information read COPYING file.\n\n"
         helptext += "More controls:\n  {prev_filter}/{next_filter}:Change Filter\n  {search}:Search\n  {addsearch}:Add\n  {reload}:Change API/Mediatype\n"
-        helptext += "  {delete}:Delete\n  {send}:Send changes\n  {sort_order}:Change sort order\n  {retrieve}:Retrieve list\n  {details}: View details\n  {open_web}: Open website\n  {openfolder}: Open folder containing show\n  {altname}:Set alternative title\n  {neweps}:Search for new episodes\n  {play_random}:Play Random\n  {switch_account}: Change account"
+        helptext += "  {delete}:Delete\n  {send}:Send changes\n  {sort_order}:Change sort order\n  {retrieve}:Retrieve list\n  {details}: View details\n  {open_web}: Open website\n  {openfolder}: Open folder containing show\n  {altname}:Set alternative title\n  {neweps}:Search for new episodes\n  {play}:Play episode or range (see syntax in CLI interface)\n  {play_random}:Play Random\n  {switch_account}: Change account"
         helptext = helptext.format(**self.keymap_str)
         ok_button = urwid.Button('OK', self.help_close)
         ok_button_wrap = urwid.Padding(urwid.AttrMap(
@@ -647,18 +643,18 @@ class Trackma_urwid:
                 self.error(e)
                 return
 
-    def play_request(self, data):
+    def play_request(self, raw_range):
         self.ask_finish(self.play_request)
-        if data:
-            item = self._get_selected_item()
-            show = self.engine.get_show_info(item.showid)
+        item = self._get_selected_item()
+        show = self.engine.get_show_info(item.showid)
 
-            try:
-                args = self.engine.play_episode(show, data)
-                utils.spawn_process(args)
-            except utils.TrackmaError as e:
-                self.error(e)
-                return
+        try:
+            ep_iter = self.engine.parse_episode_range(show, raw_range)
+            args = self.engine.play_episode(show, ep_iter)
+            utils.spawn_process(args)
+        except (utils.TrackmaError, ValueError) as e:
+            self.error(e)
+            return
 
     def prompt_update_request(self, data):
         (show, episode) = self.last_update_prompt

--- a/trackma/ui/curses.py
+++ b/trackma/ui/curses.py
@@ -360,6 +360,7 @@ class Trackma_urwid:
         item = self._get_selected_item()
         if item:
             show = self.engine.get_show_info(item.showid)
+            # TODO: use the CLI range syntax
             self.ask('[Play] Episode # to play: ',
                      self.play_request, show['my_progress']+1)
 

--- a/trackma/ui/gtk/window.py
+++ b/trackma/ui/gtk/window.py
@@ -512,7 +512,7 @@ class TrackmaWindow(Gtk.ApplicationWindow):
     def _play_next(self, show_id):
         show = self._engine.get_show_info(show_id)
         try:
-            args = self._engine.play_episode(show)
+            args = self._engine.play_episode(show, 0)
             utils.spawn_process(args)
         except utils.TrackmaError as e:
             self._error_dialog(e)

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -560,6 +560,7 @@ config_defaults = {
     'autosend_at_exit': True,
     'library_autoscan': True,
     'library_full_path': False,
+    'watch_continuously': True,
     'scan_whole_list': False,
     'debug_disable_lock': True,
     'auto_status_change': True,

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -560,7 +560,7 @@ config_defaults = {
     'autosend_at_exit': True,
     'library_autoscan': True,
     'library_full_path': False,
-    'watch_continuously': True,
+    'watch_continuously': False,
     'scan_whole_list': False,
     'debug_disable_lock': True,
     'auto_status_change': True,


### PR DESCRIPTION
Most of what is implemented here, was discussed before on #484, which will be closed if accepted. If there's any disagreement here, please read the discussion there before.


On another note, my changes `Engine.play_episode()` don't break the `episode_missing` hook API: instead of passing a copy of the `ep_iter` iterator, only the first episode number is passed. But this severely limits the power of the API in the future. If permitted, i will break the API in favor of more flexibility with it (of course, updating the hook files in the repo as well).

