### PR TITLE
Plex: Add SSL toggle

### DIFF
--- a/trackma/tracker/plex.py
+++ b/trackma/tracker/plex.py
@@ -41,6 +41,7 @@ class PlexTracker(tracker.TrackerBase):
         self.host_port = self.config['plex_host']+":"+self.config['plex_port']
         self.status_log = [None, None]
         self.token = self._get_plex_token()
+        self.http_protocol = 'https://' if self.config['plex_ssl'] else 'http://'
         super().__init__(messenger, tracker_list, config, watch_dirs, redirections)
 
     def get_plex_status(self):
@@ -64,7 +65,7 @@ class PlexTracker(tracker.TrackerBase):
             return None
 
         meta = self._get_sessions_info("Video", "key")
-        meta_url = "http://"+self.host_port+meta
+        meta_url = self.http_protocol+self.host_port+meta
         mres = self._get_xml_info(meta_url, "Part", "file")
         name = urllib.parse.unquote(ntpath.basename(mres))
         xstate = self._get_sessions_info("Player", "state")
@@ -190,7 +191,7 @@ class PlexTracker(tracker.TrackerBase):
 
     def _get_sessions_info(self, tag, attr):
         # Get the required info from the /status/sessions url
-        session_url = "http://"+self.host_port+"/status/sessions"
+        session_url = self.http_protocol+self.host_port+"/status/sessions"
         info = self._get_xml_info(session_url, tag, attr)
 
         return info

--- a/trackma/ui/gtk/data/settingswindow.ui
+++ b/trackma/ui/gtk/data/settingswindow.ui
@@ -565,6 +565,32 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbox_plex_ssl">
+                                <property name="label" translatable="yes">Use SSL</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
                             <property name="position">2</property>
                           </packing>
                         </child>

--- a/trackma/ui/gtk/settingswindow.py
+++ b/trackma/ui/gtk/settingswindow.py
@@ -64,6 +64,7 @@ class SettingsWindow(Gtk.Window):
     entry_plex_username = Gtk.Template.Child()
     entry_plex_password = Gtk.Template.Child()
     checkbox_plex_obey_wait = Gtk.Template.Child()
+    checkbox_plex_ssl = Gtk.Template.Child()
     spin_tracker_update_wait = Gtk.Template.Child()
 
     radio_tracker_jellyfin = Gtk.Template.Child()
@@ -182,6 +183,7 @@ class SettingsWindow(Gtk.Window):
 
         self.entry_plex_host.set_text(self.engine.get_config('plex_host'))
         self.spin_plex_port.set_value(int(self.engine.get_config('plex_port')))
+        self.checkbox_plex_ssl.set_active(self.engine.get_config('plex_ssl'))
         self.entry_plex_username.set_text(self.engine.get_config('plex_user'))
         self.entry_plex_password.set_text(
             self.engine.get_config('plex_passwd'))
@@ -328,6 +330,7 @@ class SettingsWindow(Gtk.Window):
         self.entry_plex_username.set_sensitive(enable)
         self.entry_plex_password.set_sensitive(enable)
         self.checkbox_plex_obey_wait.set_sensitive(enable)
+        self.checkbox_plex_ssl.set_sensitive(enable)
 
     def _enable_jellyfin(self, enable):
         self.entry_jellyfin_host.set_sensitive(enable)
@@ -376,6 +379,8 @@ class SettingsWindow(Gtk.Window):
         self.engine.set_config('plex_host', self.entry_plex_host.get_text())
         self.engine.set_config('plex_port', str(
             int(self.spin_plex_port.get_value())))
+        self.engine.set_config('plex_ssl',
+                               self.checkbox_plex_ssl.get_active())
         self.engine.set_config('plex_obey_update_wait_s',
                                self.checkbox_plex_obey_wait.get_active())
         self.engine.set_config(

--- a/trackma/ui/qt/settings.py
+++ b/trackma/ui/qt/settings.py
@@ -118,6 +118,7 @@ class SettingsDialog(QDialog):
         self.plex_passw = QLineEdit()
         self.plex_passw.setEchoMode(QLineEdit.Password)
         self.plex_obey_wait = QCheckBox()
+        self.plex_ssl = QCheckBox()
 
         g_plex_layout = QGridLayout()
         g_plex_layout.addWidget(
@@ -127,15 +128,19 @@ class SettingsDialog(QDialog):
         g_plex_layout.addWidget(self.plex_port,
                                 0, 2, 1, 2)
         g_plex_layout.addWidget(
-            QLabel('Use "wait before updating" time'), 1, 0, 1, 1)
-        g_plex_layout.addWidget(self.plex_obey_wait,
+            QLabel('Use SSL'), 1, 0, 1, 1)
+        g_plex_layout.addWidget(self.plex_ssl,
                                 1, 2, 1, 1)
         g_plex_layout.addWidget(
-            QLabel('myPlex login (claimed server)'),   2, 0, 1, 1)
+            QLabel('Use "wait before updating" time'), 2, 0, 1, 1)
+        g_plex_layout.addWidget(self.plex_obey_wait,
+                                2, 2, 1, 1)
+        g_plex_layout.addWidget(
+            QLabel('myPlex login (claimed server)'),   3, 0, 1, 1)
         g_plex_layout.addWidget(self.plex_user,
-                                2, 1, 1, 1)
+                                3, 1, 1, 1)
         g_plex_layout.addWidget(self.plex_passw,
-                                2, 2, 1, 2)
+                                3, 2, 1, 2)
 
         g_plex.setLayout(g_plex_layout)
 
@@ -509,6 +514,8 @@ class SettingsDialog(QDialog):
 
         self.plex_host.setText(engine.get_config('plex_host'))
         self.plex_port.setText(engine.get_config('plex_port'))
+        self.plex_ssl.setChecked(
+            engine.get_config('plex_ssl'))
         self.plex_obey_wait.setChecked(
             engine.get_config('plex_obey_update_wait_s'))
         self.plex_user.setText(engine.get_config('plex_user'))
@@ -618,6 +625,7 @@ class SettingsDialog(QDialog):
         engine.set_config('plex_port',         self.plex_port.text())
         engine.set_config('plex_obey_update_wait_s',
                           self.plex_obey_wait.isChecked())
+        engine.set_config('plex_ssl',          self.plex_ssl.isChecked())
         engine.set_config('plex_user',         self.plex_user.text())
         engine.set_config('plex_passwd',       self.plex_passw.text())
 
@@ -708,6 +716,7 @@ class SettingsDialog(QDialog):
         self.plex_user.setEnabled(state)
         self.plex_passw.setEnabled(state)
         self.plex_obey_wait.setEnabled(state)
+        self.plex_ssl.setEnabled(state)
 
     def switch_jellyfin_state(self, state):
         self.jellyfin_host.setEnabled(state)

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -581,6 +581,7 @@ config_defaults = {
     'plex_user': '',
     'plex_passwd': '',
     'plex_uuid': str(uuid.uuid1()),
+    'plex_ssl': False,
     'jellyfin_host': "localhost",
     'jellyfin_port': "8096",
     'jellyfin_api_key': '',


### PR DESCRIPTION
This would be a solution for Issue #369. 

The hardcoded http prevents any secure connections from being used. This pull request adds a configuration option to use ssl, which then prefixes https. This is not a perfect fix since it will still run into SSL certificate errors if only the server IP is used, but if the plex.direct url of the server is used, to which the certificate is issues it works without a problem.

Alternatively the SSL verification can be turned off, but that is not a good solution even if this solution puts the onus on the user to use the correct URL instead of simply the IP.

This fix also adds a checkbox toggle for the setting to the qt and gtk setting windows.