### PR TITLE
Partial paginated search implementation

### DIFF
--- a/trackma/data.py
+++ b/trackma/data.py
@@ -213,12 +213,12 @@ class Data:
         """Get list from memory"""
         return self.showlist
 
-    def search(self, criteria, method):
+    def search(self, criteria, method, page):
         # Tell API to search
-        results = self.api.search(criteria, method)
+        results = self.api.search(criteria, method, page or 1)
         self.api.logout()
         if results:
-            return results
+            return results if page else results[0]
 
         raise utils.DataError('No results.')
 

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -481,7 +481,7 @@ class Engine:
 
         return None
 
-    def search(self, criteria, method=utils.SearchMethod.KW):
+    def search(self, criteria, method=utils.SearchMethod.KW, page=None):
         """
         Request a remote list of shows matching the criteria
         and returns it as a list of show dictionaries.
@@ -491,7 +491,7 @@ class Engine:
             raise utils.EngineError(
                 'Search method not supported by API or mediatype.')
 
-        return self.data_handler.search(criteria, method)
+        return self.data_handler.search(criteria, method, page)
 
     def add_show(self, show, status=None):
         """

--- a/trackma/lib/lib.py
+++ b/trackma/lib/lib.py
@@ -138,7 +138,7 @@ class lib:
         """
         raise NotImplementedError
 
-    def search(self, criteria, method):
+    def search(self, criteria, method, page):
         """
         Called when the data handler needs a detailed list of shows from the remote server.
         It should return a list of show dictionaries with the additional 'extra' key (which is a list of tuples)

--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -374,7 +374,7 @@ fragment mediaListEntry on MediaList {
         variables = {'id': item['my_id']}
         self._request(query, variables)
 
-    def search(self, criteria, method):
+    def search(self, criteria, method, page):
         self.check_credentials()
         self.msg.info("Searching for {}...".format(criteria))
 
@@ -415,7 +415,7 @@ fragment mediaListEntry on MediaList {
             infolist.append(self._parse_info(media))
 
         self._emit_signal('show_info_changed', infolist)
-        return infolist
+        return (infolist, len(infolist), 1, 1)
 
     def request_info(self, itemlist):
         self.check_credentials()

--- a/trackma/lib/libkitsu.py
+++ b/trackma/lib/libkitsu.py
@@ -454,16 +454,20 @@ class libkitsu(lib):
 
     def search(self, query, method, page):
         self.msg.info("Searching for %s..." % query)
+        item_per_page = 20
 
         values = {
             "filter[text]": query,
-            "page[limit]": 20,
+            "page[limit]":  item_per_page,
+            "page[offset]": (page - 1) * item_per_page
         }
 
         try:
             data = self._request('GET', self.prefix +
                                  "/" + self.mediatype, get=values)
             shows = json.loads(data)
+            pages = int(shows['meta']['count'] / item_per_page) + \
+                    1 if shows['meta']['count'] % item_per_page != 0 else 0
 
             infolist = []
             for media in shows['data']:
@@ -475,7 +479,7 @@ class libkitsu(lib):
             if not infolist:
                 raise utils.APIError('No results.')
 
-            return (infolist, len(infolist), 1, 1,)
+            return (infolist, shows['meta']['count'], page, pages,)
         except urllib.error.HTTPError as e:
             raise utils.APIError('Error searching: ' + str(e.code))
         except urllib.error.URLError as e:

--- a/trackma/lib/libkitsu.py
+++ b/trackma/lib/libkitsu.py
@@ -452,7 +452,7 @@ class libkitsu(lib):
         except urllib.error.URLError as e:
             raise utils.APIError('Error deleting: ' + str(e.reason))
 
-    def search(self, query, method):
+    def search(self, query, method, page):
         self.msg.info("Searching for %s..." % query)
 
         values = {
@@ -475,7 +475,7 @@ class libkitsu(lib):
             if not infolist:
                 raise utils.APIError('No results.')
 
-            return infolist
+            return (infolist, len(infolist), 1, 1,)
         except urllib.error.HTTPError as e:
             raise utils.APIError('Error searching: ' + str(e.code))
         except urllib.error.URLError as e:

--- a/trackma/lib/libmal.py
+++ b/trackma/lib/libmal.py
@@ -308,7 +308,7 @@ class libmal(lib):
         self.msg.info("Deleting item %s..." % item['title'])
         data = self._request('DELETE', self.query_url + '/%s/%d/my_list_status' % (self.mediatype, item['id']), auth=True)
     
-    def search(self, criteria, method):
+    def search(self, criteria, method, page):
         self.check_credentials()
         self.msg.info("Searching for {}...".format(criteria))
         
@@ -333,7 +333,7 @@ class libmal(lib):
             results.append(self._parse_info(item['node']))
         
         self._emit_signal('show_info_changed', results)
-        return results
+        return (results, len(results), 1, 1)
         
     def request_info(self, itemlist):
         self.check_credentials()

--- a/trackma/lib/libshikimori.py
+++ b/trackma/lib/libshikimori.py
@@ -282,7 +282,7 @@ class libshikimori(lib):
         data = self._request(
             "DELETE", self.api_url + "/user_rates/{}".format(item['my_id']), auth=True)
 
-    def search(self, criteria, method):
+    def search(self, criteria, method, page):
         self.check_credentials()
 
         self.msg.info("Searching for {}...".format(criteria))
@@ -293,7 +293,7 @@ class libshikimori(lib):
         except ValueError:
             # An empty document, without any JSON, is returned
             # when there are no results.
-            return []
+            return ([], 0, 0, 0)
 
         showlist = []
 
@@ -314,7 +314,7 @@ class libshikimori(lib):
 
             showlist.append(show)
 
-        return showlist
+        return (showlist, len(showlist), 1, 1)
 
     def request_info(self, itemlist):
         self.check_credentials()

--- a/trackma/lib/libvndb.py
+++ b/trackma/lib/libvndb.py
@@ -321,14 +321,14 @@ class libvndb(lib):
         if name != 'ok':
             raise utils.APIError("Invalid response (%s)" % name)
 
-    def search(self, criteria, method):
+    def search(self, criteria, method, page):
         self.check_credentials()
 
         results = list()
         self.msg.info('Searching for %s...' % criteria)
 
         (name, data) = self._sendcmd('get vn basic,details (search ~ "%s")' % criteria,
-                                     {'page': 1,
+                                     {'page': page,
                                       'results': self.pagesize_details,
                                       })
 
@@ -345,7 +345,7 @@ class libvndb(lib):
         if not results:
             raise utils.APIError('No results.')
 
-        return results
+        return (results, len(results), 1, 1)
 
     def logout(self):
         self.msg.info('Disconnecting...')

--- a/trackma/ui/gtk/data/searchwindow.ui
+++ b/trackma/ui/gtk/data/searchwindow.ui
@@ -3,56 +3,32 @@
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <template class="SearchWindow" parent="GtkWindow">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="modal">True</property>
-    <property name="default_width">800</property>
-    <property name="default_height">400</property>
-    <property name="type_hint">dialog</property>
-    <child type="titlebar">
-      <object class="GtkHeaderBar" id="headerbar">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="title" translatable="yes">Search</property>
-        <property name="show_close_button">True</property>
-        <child>
-          <object class="GtkButton" id="btn_add_show">
-            <property name="label" translatable="yes">Add</property>
-            <property name="visible">True</property>
-            <property name="sensitive">False</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <signal name="clicked" handler="_on_btn_add_show_clicked" swapped="no"/>
-            <style>
-              <class name="suggested-action"/>
-            </style>
-          </object>
-          <packing>
-            <property name="pack_type">end</property>
-          </packing>
-        </child>
-      </object>
-    </child>
+    <property name="default-width">800</property>
+    <property name="default-height">400</property>
+    <property name="type-hint">dialog</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
-            <property name="margin_top">6</property>
-            <property name="margin_bottom">6</property>
+            <property name="margin-top">6</property>
+            <property name="margin-bottom">6</property>
             <property name="spacing">9</property>
             <child>
               <object class="GtkSearchEntry" id="search_entry">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="primary_icon_name">edit-find-symbolic</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="primary_icon_sensitive">False</property>
+                <property name="can-focus">True</property>
+                <property name="primary-icon-name">edit-find-symbolic</property>
+                <property name="primary-icon-activatable">False</property>
+                <property name="primary-icon-sensitive">False</property>
                 <signal name="search-changed" handler="_on_search_entry_search_changed" swapped="no"/>
               </object>
               <packing>
@@ -64,7 +40,7 @@
             <child>
               <object class="GtkSpinner" id="progress_spinner">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
               </object>
@@ -84,7 +60,7 @@
         <child>
           <object class="GtkSeparator">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -95,16 +71,16 @@
         <child>
           <object class="GtkPaned" id="search_paned">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkScrolledWindow">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <child>
                   <object class="GtkViewport" id="shows_viewport">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="shadow_type">none</property>
+                    <property name="can-focus">False</property>
+                    <property name="shadow-type">none</property>
                     <child>
                       <placeholder/>
                     </child>
@@ -119,7 +95,7 @@
             <child>
               <object class="GtkBox" id="show_info_container">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <child>
                   <placeholder/>
                 </child>
@@ -138,5 +114,146 @@
         </child>
       </object>
     </child>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="headerbar">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="title" translatable="yes">Search</property>
+        <property name="show-close-button">True</property>
+        <child>
+          <object class="GtkButton" id="btn_add_show">
+            <property name="label" translatable="yes">Add</property>
+            <property name="visible">True</property>
+            <property name="sensitive">False</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <signal name="clicked" handler="_on_btn_add_show_clicked" swapped="no"/>
+            <style>
+              <class name="suggested-action"/>
+            </style>
+          </object>
+          <packing>
+            <property name="pack-type">end</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButtonBox" id="paginator">
+            <property name="can-focus">False</property>
+            <property name="no-show-all">True</property>
+            <property name="layout-style">start</property>
+            <child type="center">
+              <object class="GtkButton" id="next_page">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="_on_next_page_clicked" swapped="no"/>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="icon-name">go-next</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+                <property name="non-homogeneous">True</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="prev_page">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="_on_prev_page_clicked" swapped="no"/>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="icon-name">go-previous</property>
+                    <property name="icon_size">2</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+                <property name="non-homogeneous">True</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="select_page">
+                <property name="label" translatable="yes">-</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="_on_select_page_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+                <property name="non-homogeneous">True</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
   </template>
+  <object class="GtkPopover" id="page_popover">
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="margin-start">8</property>
+        <property name="margin-end">8</property>
+        <property name="margin-top">8</property>
+        <property name="margin-bottom">8</property>
+        <property name="spacing">6</property>
+        <child>
+          <object class="GtkEntry" id="page_entry">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <signal name="activate" handler="_on_page_change" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="entry_done">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <signal name="clicked" handler="_on_page_change" swapped="no"/>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="icon-name">object-select-symbolic</property>
+              </object>
+            </child>
+            <style>
+              <class name="suggested-action"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
 </interface>

--- a/trackma/ui/gtk/mainview.py
+++ b/trackma/ui/gtk/mainview.py
@@ -534,7 +534,6 @@ class MainView(Gtk.Box):
         self.emit('show-action', event_type, data)
 
     def get_current_status(self):
-        print(self._engine.mediainfo['statuses'])
         return self._current_page.status if self._current_page.status is not None else self._engine.mediainfo['statuses'][-1]
 
     def get_selected_show(self):


### PR DESCRIPTION
- engine: Add pagination support skeleton
- kitsu: Implement paginated search
- Gtk: Implement paginated search

![Pagination in search dialog](https://user-images.githubusercontent.com/24864366/233618279-24f257db-ae49-4849-b3ea-cb65cc297e0d.png)


### Implementation
1. API libraries must implement paginated `.search()`, if pagination is unsupported, page count will be 1
1. If `engine.search(...)` is called with `page=N` ti returns paginated result, otherwise it returns an array of first n results (old behavior)
1. paginated results are returned like this `[ results[], len(results[]), pagenum, pages ]`

Related #687 