### PR TITLE
Change Shikimori endpoints from .org to .me

### DIFF
--- a/trackma/lib/libshikimori.py
+++ b/trackma/lib/libshikimori.py
@@ -29,7 +29,7 @@ class libshikimori(lib):
     """
     API class to communicate with Shikimori
 
-    Website: https://shikimori.org
+    Website: https://shikimori.me
 
     messenger: Messenger object to send useful messages to
     """
@@ -90,9 +90,9 @@ class libshikimori(lib):
     # Supported signals for the data handler
     signals = {'show_info_changed': None, }
 
-    url = "https://shikimori.org"
-    auth_url = "https://shikimori.org/oauth/token"
-    api_url = "https://shikimori.org/api"
+    url = "https://shikimori.me"
+    auth_url = "https://shikimori.me/oauth/token"
+    api_url = "https://shikimori.me/api"
 
     client_id = "Jfu9MKkUKPG4fOC95A6uwUVLHy3pwMo3jJB7YLSp7Ro"
     client_secret = "y7YmQx8n1l7eBRugUSiB7NfNJxaNBMvwppfxJLormXU"


### PR DESCRIPTION
Shikimori changed its domain to `shikimori.me`:
- https://shikimori.me/forum/news/505429-novyy-domen-sayta-shikimori-me
- https://shikimori.me/forum/news/506738-novyy-domen-sayta-shikimori-me-v2

`shikimori.org` and `shikimori.one` still work, but they are left for compatibility.

Changes were tested by trying to log in via personal shikimori account.