### PR TITLE
Update episode_missing_ani-cli.py

### DIFF
--- a/hooks/episode_missing_ani-cli.py
+++ b/hooks/episode_missing_ani-cli.py
@@ -16,7 +16,7 @@ def episode_missing(engine, show, episode):
     query = show["title"].strip()
     anicli = shutil.which("ani-cli")  # find 'ani-cli' executable
     if anicli:
-        args = [anicli, "-q", "best", "-a", str(episode), query]
+        args = [anicli, "-q", "best", "-e", str(episode), query]
         cmd = " ".join(args[:-1]) + f" '{query}'"
         engine.msg.info("episode_missing", cmd)  # Show the command used
         utils.spawn_process(args)


### PR DESCRIPTION
ani-cli now uses "-e" instead of "-a" for episode indication option.