### PR TITLE
Qt: Replace Image.ANTIALIAS with Image.LANCZOS

### DIFF
--- a/trackma/ui/qt/workers.py
+++ b/trackma/ui/qt/workers.py
@@ -55,7 +55,7 @@ class ImageWorker(QtCore.QThread):
             if self.size:
                 if "imaging_available" in os.environ:
                     im = Image.open(img_file)
-                    im.thumbnail((self.size[0], self.size[1]), Image.ANTIALIAS)
+                    im.thumbnail((self.size[0], self.size[1]), Image.LANCZOS)
                     im.convert("RGB").save(self.local)
             else:
                 with open(self.local, 'wb') as f:


### PR DESCRIPTION
Image.ANTIALIAS has been removed in PIL 10.0.0: https://pillow.readthedocs.io/en/stable/deprecations.html
Image.LANCZOS is backwards compatible.