### PR TITLE
Replace Image.ANTIALIAS with Image.BICUBIC in QT and GTK

### DIFF
--- a/trackma/ui/gtk/imagebox.py
+++ b/trackma/ui/gtk/imagebox.py
@@ -58,7 +58,7 @@ class ImageThread(threading.Thread):
     def _save_image(self, img_bytes):
         if imaging_available:
             image = Image.open(img_bytes)
-            image.thumbnail((self._width, self._height), Image.ANTIALIAS)
+            image.thumbnail((self._width, self._height), Image.BICUBIC)
             image.convert("RGB").save(self._filename)
         else:
             with open(self._filename, 'wb') as img_file:

--- a/trackma/ui/qt/workers.py
+++ b/trackma/ui/qt/workers.py
@@ -55,7 +55,7 @@ class ImageWorker(QtCore.QThread):
             if self.size:
                 if "imaging_available" in os.environ:
                     im = Image.open(img_file)
-                    im.thumbnail((self.size[0], self.size[1]), Image.ANTIALIAS)
+                    im.thumbnail((self.size[0], self.size[1]), Image.BICUBIC)
                     im.convert("RGB").save(self.local)
             else:
                 with open(self.local, 'wb') as f:


### PR DESCRIPTION
Image.ANTIALIAS has been removed in PIL 10.0.0: https://pillow.readthedocs.io/en/stable/deprecations.html
Image.LANCZOS is identical but [it seems like overkill](https://github.com/z411/trackma/issues/698#issuecomment-1627437824).