### PR TITLE
add support for cm and tv_special media type on mal

### DIFF
--- a/trackma/lib/libmal.py
+++ b/trackma/lib/libmal.py
@@ -105,6 +105,8 @@ class libmal(lib):
         'manhua': utils.Type.MANGA,
         'one_shot': utils.Type.ONE_SHOT,
         'doujinshi': utils.Type.MANGA,
+        'cm':utils.Type.OTHER,
+        'tv_special': utils.Type.SPECIAL
     }
     
     status_translate = {


### PR DESCRIPTION
i found that MAL has type "cm" and type "tv_special" as media type and it crashed my trackma.
I'm not entirely sure if cm stands for commercial or for something else, so i defined it as utils.Type.other  
while tv_special gets redirected to specials so i put it as  utils.Type.special

examples
cm: Mirai no Watashi
tv_spcial: Wonder Egg Priority: Watashi no Priority

sry if something is missing it's my first pr