### PR TITLE
Unification of 'open-folder' function, should fix 'xdg-open' path error

### DIFF
--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -523,8 +523,11 @@ class Trackma_cmd(command.Cmd):
             self.display_error(e)
 
     def do_openfolder(self, args):
-        show_id = self._get_show(args[0])['id']
-        utils.open_folder(self.engine, show_id, error_callback=self.display_error)
+        try:
+            show_id = self._get_show(args[0])['id']
+            utils.open_folder(self.engine, show_id, error_callback=self.display_error)
+        except utils.TrackmaError as e:
+            self.display_error(e)
 
     def do_update(self, args):
         """

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -523,8 +523,8 @@ class Trackma_cmd(command.Cmd):
             self.display_error(e)
 
     def do_openfolder(self, args):
-        show = self._get_show(args[0])
-        utils.open_folder(self.engine, show.id, error_callback=self.display_error)
+        show_id = self._get_show(args[0])['id']
+        utils.open_folder(self.engine, show_id, error_callback=self.display_error)
 
     def do_update(self, args):
         """

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -523,31 +523,8 @@ class Trackma_cmd(command.Cmd):
             self.display_error(e)
 
     def do_openfolder(self, args):
-        """
-        Opens the folder containing the show
-
-        :param show Show index or name.
-        :usage openfolder <show index or name>
-        """
-
-        try:
-            show = self._get_show(args[0])
-            filename = self.engine.get_episode_path(show)
-            with open(os.devnull, 'wb') as DEVNULL:
-                if sys.platform == 'darwin':
-                    subprocess.Popen(["open",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-                elif sys.platform == 'win32':
-                    subprocess.Popen(["explorer",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-                else:
-                    subprocess.Popen(["/usr/bin/xdg-open",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-        except OSError:
-            # xdg-open failed.
-            self.display_error("Could not open folder.")
-        except utils.TrackmaError as e:
-            self.display_error(e)
+        show = self._get_show(args[0])
+        utils.open_folder(self.engine, show.id, error_callback=self.display_error)
 
     def do_update(self, args):
         """

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -523,6 +523,13 @@ class Trackma_cmd(command.Cmd):
             self.display_error(e)
 
     def do_openfolder(self, args):
+        """
+        Opens the folder containing the show
+
+        :param show Show index or name.
+        :usage openfolder <show index or name>
+        """
+
         try:
             show_id = self._get_show(args[0])['id']
             utils.open_folder(self.engine, show_id, error_callback=self.display_error)

--- a/trackma/ui/curses.py
+++ b/trackma/ui/curses.py
@@ -365,27 +365,7 @@ class Trackma_urwid:
 
     def do_openfolder(self):
         item = self._get_selected_item()
-
-        try:
-            show = self.engine.get_show_info(item.showid)
-            filename = self.engine.get_episode_path(show)
-            with open(os.devnull, 'wb') as DEVNULL:
-                if sys.platform == 'darwin':
-                    subprocess.Popen(["open",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-                elif sys.platform == 'win32':
-                    subprocess.Popen(["explorer",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-                else:
-                    subprocess.Popen(["/usr/bin/xdg-open",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-        except OSError:
-            # xdg-open failed.
-            raise utils.EngineError("Could not open folder.")
-
-        except utils.EngineError:
-            # Show not in library.
-            self.error("No folder found.")
+        utils.open_folder(self.engine, item.showid, error_callback=self.error)
 
     def do_play_random(self):
         try:

--- a/trackma/ui/gtk/window.py
+++ b/trackma/ui/gtk/window.py
@@ -573,29 +573,7 @@ class TrackmaWindow(Gtk.ApplicationWindow):
             Gtk.show_uri(None, show['url'], Gdk.CURRENT_TIME)
 
     def _open_folder(self, show_id):
-        show = self._engine.get_show_info(show_id)
-        try:
-            filename = self._engine.get_episode_path(show)
-            with open(os.devnull, 'wb') as DEVNULL:
-                if sys.platform == 'darwin':
-                    subprocess.Popen(["open", os.path.dirname(filename)],
-                                     stdout=DEVNULL,
-                                     stderr=DEVNULL)
-                elif sys.platform == 'win32':
-                    subprocess.Popen(["explorer", os.path.dirname(filename)],
-                                     stdout=DEVNULL,
-                                     stderr=DEVNULL)
-                else:
-                    subprocess.Popen(["/usr/bin/xdg-open", os.path.dirname(filename)],
-                                     stdout=DEVNULL,
-                                     stderr=DEVNULL)
-        except OSError:
-            # xdg-open failed.
-            raise utils.EngineError("Could not open folder.")
-
-        except utils.EngineError:
-            # Show not in library.
-            self._error_dialog_idle("No folder found.")
+        utils.open_folder(self._engine, show_id, error_callback=self._error_dialog_idle)
 
     def _copy_title(self, show_id):
         show = self._engine.get_show_info(show_id)

--- a/trackma/ui/qt/mainwindow.py
+++ b/trackma/ui/qt/mainwindow.py
@@ -1183,26 +1183,7 @@ class MainWindow(QMainWindow):
             self.ws_changed_show(show, altname=new_altname)
 
     def s_open_folder(self):
-        show = self.worker.engine.get_show_info(self.selected_show_id)
-        try:
-            filename = self.worker.engine.get_episode_path(show)
-            with open(os.devnull, 'wb') as DEVNULL:
-                if sys.platform == 'darwin':
-                    subprocess.Popen(["open",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-                elif sys.platform == 'win32':
-                    subprocess.Popen(["explorer",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-                else:
-                    subprocess.Popen(["/usr/bin/xdg-open",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-        except OSError:
-            # xdg-open failed.
-            raise utils.EngineError("Could not open folder.")
-
-        except utils.EngineError:
-            # Show not in library.
-            self.error("No folder found.")
+        utils.open_folder(self.worker.engine, self.selected_show_id, error_callback=self.error)
 
     def s_retrieve(self):
         queue = self.worker.engine.get_queue()

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -490,6 +490,37 @@ def get_terminal_size(fd=1):
     return hw
 
 
+def open_folder(engine, show_id, error_callback=None):
+    try:
+        show_to_open = engine.get_show_info(show_id)
+        filename = engine.get_episode_path(show_to_open)
+        with open(os.devnull, 'wb') as DEVNULL:
+            if sys.platform == 'darwin':
+                subprocess.Popen(["open", os.path.dirname(filename)],
+                                 stdout=DEVNULL,
+                                 stderr=DEVNULL)
+            elif sys.platform == 'win32':
+                subprocess.Popen(["explorer", os.path.dirname(filename)],
+                                 stdout=DEVNULL,
+                                 stderr=DEVNULL)
+            else:
+                subprocess.Popen(["xdg-open", os.path.dirname(filename)],
+                                 stdout=DEVNULL,
+                                 stderr=DEVNULL)
+    except OSError:
+        # Open failed.
+        if error_callback:
+            error_callback("Could not open folder.")
+        else:
+            raise EngineError("Could not open folder.")
+    except EngineError:
+        # Show not in library.
+        if error_callback:
+            error_callback("No folder found.")
+        else:
+            raise EngineError("No folder found.")
+
+
 def show():
     return {
         'id':           0,

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -507,18 +507,11 @@ def open_folder(engine, show_id, error_callback=None):
                 subprocess.Popen(["xdg-open", os.path.dirname(filename)],
                                  stdout=DEVNULL,
                                  stderr=DEVNULL)
-    except OSError:
-        # Open failed.
+    except Exception as e:
         if error_callback:
-            error_callback("Could not open folder.")
+            error_callback(e)
         else:
-            raise EngineError("Could not open folder.")
-    except EngineError:
-        # Show not in library.
-        if error_callback:
-            error_callback("No folder found.")
-        else:
-            raise EngineError("No folder found.")
+            raise e
 
 
 def show():

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -490,7 +490,14 @@ def get_terminal_size(fd=1):
     return hw
 
 
+# Default 'open folder' function
 def open_folder(engine, show_id, error_callback=None):
+    """
+    Tries to open the folder containing the show of the passed ID.
+    Takes an optional 'error_callback' parameter that lets the invoker specify an error callback method.
+    If no error callback is passed, it defaults to simply raising.
+    """
+
     try:
         show_to_open = engine.get_show_info(show_id)
         filename = engine.get_episode_path(show_to_open)

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -517,12 +517,17 @@ def open_folder(engine, show_id, error_callback=None):
                 # Command failed.
                 raise OSError(stderr)
 
+    except OSError as e:
+        if error_callback:
+            error_callback(f'Could not open folder.\n{e}')
+        else:
+            raise e
+
     except Exception as e:
         if error_callback:
             error_callback(e)
         else:
             raise e
-
 
 
 def show():


### PR DESCRIPTION
Should fix #726 as long as `xdg-open` is in `$PATH`, which can be assumed for every distro. I tested it for GTK, Qt and CLI on Fedora 39.

> [!CAUTION]
> **As my other PR (#722), this requires python 3.10. Do not merge before #722 or without updating python dep.**

# Changes
## Code
- Unified all 'open folder' functions in `utils.py`. Can take an `error_callback` param so error reporting can still be done uniquely for every UI.
- Fixed OSError not being raised when the folder was in the library, but was changed after scanning. I.e:
	1. Start trackma
	2. 'Show X' gets scanned and found
	3. Rename folder of 'show X'
	4. Open folder
	5. Error is raised correctly
