### PR TITLE
MAL: fallback to Unknown if media_type not in type_translate

### DIFF
--- a/trackma/lib/libmal.py
+++ b/trackma/lib/libmal.py
@@ -379,7 +379,7 @@ class libmal(lib):
             'title': item['title'],
             'url': "https://myanimelist.net/%s/%d" % (self.mediatype, showid),
             'aliases': self._get_aliases(item),
-            'type': self.type_translate[item['media_type']],
+            'type': self.type_translate.get(item['media_type'], utils.Type.UNKNOWN),    
             'total': item[self.total_str],
             'status': self._translate_status(item['status']),
             'image': item.get('main_picture', {}).get('large'),


### PR DESCRIPTION
will prevent crash in cli/qt and infinit loading in gtk  if `item['media_type']` not in `self.type_translate`, now it  falls back to `utils.Type.UNKNOWN`.
eg.  `Mahoutsukai Reimeiki PV` with the media_type `pv` which is not a key in type_translate.

Could of cause be also fixed by adding `pv` to type_translate but then if something else is not in type_translate, it will crash and  a new fix would be needed.