### PR TITLE
[Kitsu API] migrate from kitsu.io to kitsu.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Currently supported websites
 ----------------------------
 
 - [Anilist](https://anilist.co/) (Anime, Manga)
-- [Kitsu](https://kitsu.io/) (Anime, Manga, Drama)
+- [Kitsu](https://kitsu.app/) (Anime, Manga, Drama)
 - [MyAnimeList](https://myanimelist.net/) (Anime, Manga)
 - [Shikimori](http://shikimori.org/) (Anime, Manga)
 - [VNDB](https://vndb.org/) (VNs)

--- a/trackma/lib/libkitsu.py
+++ b/trackma/lib/libkitsu.py
@@ -16,9 +16,9 @@
 #
 
 """
-Media list provider using Kitsu <https://kitsu.io>.
+Media list provider using Kitsu <https://kitsu.app>.
 
-Example API response: https://kitsu.io/api/edge/anime?filter[text]=build+divide
+Example API response: https://kitsu.app/api/edge/anime?filter[text]=build+divide
 """
 
 import datetime
@@ -48,7 +48,7 @@ class libkitsu(lib):
     API class to communicate with Kitsu
     Should inherit a base library interface.
 
-    Website: https://kitsu.io/
+    Website: https://kitsu.app/
     API documentation:
     Designed by:
 
@@ -131,8 +131,8 @@ class libkitsu(lib):
         'score_step': 0.25,
     }
 
-    url = 'https://kitsu.io/api'
-    prefix = 'https://kitsu.io/api/edge'
+    url = 'https://kitsu.app/api'
+    prefix = 'https://kitsu.app/api/edge'
 
     # TODO : These values are provisional.
     _client_id = 'dd031b32d2f56c990b1425efe6c42ad847e7fe3ab46bf1299f05ecd856bdb7dd'
@@ -578,7 +578,7 @@ class libkitsu(lib):
             'end_date':    self._str2date(attr['endDate']),
             'type':        self.type_translate.get(attr['subtype'], utils.Type.UNKNOWN),
             'status':      self.status_translate.get(attr['status'], utils.Status.UNKNOWN),
-            'url': "https://kitsu.io/{}/{}".format(self.mediatype, attr['slug']),
+            'url': "https://kitsu.app/{}/{}".format(self.mediatype, attr['slug']),
             'aliases':     list(filter(None, attr['titles'].values())),
             'extra': [
                 ('Synopsis',            attr['description']),


### PR DESCRIPTION
The [kitsu.io](https://kitsu.io) domain has expired, and the main developers do not have access to that domain. So they [migrated](https://github.com/hummingbird-me/kitsu-server/issues/1556#issuecomment-2282590908) to the new [kitsu.app](https://kitsu.app) domain.

This pull request updates all references of `kitsu.io` to `kitsu.app`.