### PR TITLE
Remove debug prints of cache hits during scanning

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -836,9 +836,7 @@ class Engine:
                     (show_ep_start, show_ep_end) = show_ep
                 else:
                     show_ep_start = show_ep_end = show_ep
-                self.msg.debug("File in cache: {}".format(fullpath))
             else:
-                self.msg.debug("File in cache but skipped: {}".format(fullpath))
                 return library, library_cache
         else:
             # If the filename has not been seen, extract


### PR DESCRIPTION
They are annoying and pretty useless. A full rescan will show better diagnostics for why a certain file wouldn't be recognized.

I've removed these locally many months ago and haven't missed them once.