### PR TITLE
Redirect only invalid episodes

### DIFF
--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -416,8 +416,11 @@ def redirect_show(show_tuple, redirections, tracker_list):
         return show_tuple
 
     (show, ep) = show_tuple
-    showlist = tracker_list[0]
+    if show.get('total') and ep <= show['total']:
+        # redirect only for invalid ep
+        return show_tuple
 
+    showlist = tracker_list[0]
     if show['id'] in redirections:
         for redirection in redirections[show['id']]:
             (src_eps, dst_id, dst_eps) = redirection


### PR DESCRIPTION
Without this check, we would not be able to handle overlapping self-redirects, which is something that occurs in anime-relations.txt and that taiga handles by simply only redirecting if the recognized episode number is invalid. So we match this behavior.

See also https://github.com/erengy/anime-relations/issues/181.