### PR TITLE
Add caching to library rescan

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -808,12 +808,11 @@ class Engine:
         # Only remove if the filename matches library entry
         if filename in library_cache and library_cache[filename]:
             (show_id, show_ep) = library_cache[filename]
-            if show_id and show_id in library \
-                    and show_ep and show_ep in library[show_id].keys():
-                if library[show_id][show_ep] == fullpath:
-                    self.msg.debug("File removed from local library: %s" % fullpath)
-                    library_cache.pop(filename, None)
-                    library[show_id].pop(show_ep, None)
+            if show_id and show_ep and show_id \
+                    and library.get(show_id, {}).get(show_ep) == fullpath:
+                self.msg.debug("File removed from local library: %s" % fullpath)
+                library_cache.pop(filename, None)
+                library[show_id].pop(show_ep, None)
 
     def add_to_library(self, path, filename, rescan=False):
         # The inotify tracker tells us when files are created in


### PR DESCRIPTION
The multi-minute waiting time for a library rescan has been getting on my nerves for years now but today was finally the day I actually implemented caching. Since the standard number of episodes of a show is 12 episodes with some having more, this caching approximates to an at least 10x speedup in "usual" setups.

It's not the most ideal implementation but it works.

(Whenever I work on the trackma codebase, I feel how dated it is. The lack of type hinting and the questionable formatting definitely needs work, but that is for another time.)