### PR TITLE
cli: add optional path parameter for the "rescan" command

### DIFF
--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -80,6 +80,7 @@ class Trackma_cmd(command.Cmd):
         'delete':       1,
         'play':         (1, 2),
         'openfolder':   1,
+        'rescan':       (0, 1),
         'update':       (1, 2),
         'score':        2,
         'status':       2,
@@ -449,8 +450,12 @@ class Trackma_cmd(command.Cmd):
     def do_rescan(self, args):
         """
         Re-scans the local library.
+
+        :optparam path Base path for the scan. Defaults to all library folders if omitted.
+        :usage rescan [path to re-scan]
         """
-        self.engine.scan_library(rescan=True)
+        path = args[0] if args else None
+        self.engine.scan_library(rescan=True, path=path)
 
     def do_random(self, args):
         """


### PR DESCRIPTION
Helps to rescan particular folders only, e.g. after adding an altname or when new files were added and the inotify tracker isn't used.

Improves the situation described in #677 but does not add a GUI option. I'm not sure if a GUI command for this functionality is even wanted by users (especially now that a rescan is much faster with #748).