### PR TITLE
cli: Rename `undoall` to `clearqueue`

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -979,7 +979,7 @@ class Engine:
         args.append(filename)
         return args
 
-    def undoall(self):
+    def queue_clear(self):
         """Clears the data handler queue and discards any unsynced change."""
         return self.data_handler.queue_clear()
 
@@ -1016,7 +1016,7 @@ class Engine:
 
     def list_download(self):
         """Asks the data handler to download the remote list."""
-        self.undoall()
+        self.data_handler.queue_clear()
         self.data_handler.download_data()
         self._update_tracker()
 

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -670,12 +670,12 @@ class Trackma_cmd(command.Cmd):
         except utils.TrackmaError as e:
             self.display_error(e)
 
-    def do_undoall(self, args):
+    def do_clearqueue(self, args):
         """
         Undo all changes in queue.
         """
         try:
-            self.engine.undoall()
+            self.engine.queue_clear()
         except utils.TrackmaError as e:
             self.display_error(e)
 


### PR DESCRIPTION
Clarifies that it does not undo the local changes (that's done by `retrieve`) and has symmetry with `viewqueue`.

Closes #681
