### PR TITLE
fix: hooks not loading on python 3.13

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -305,6 +305,7 @@ class Engine:
             hooks_dir = utils.to_config_path('hooks')
             if os.path.isdir(hooks_dir):
                 import pkgutil
+                import importlib
 
                 self.msg.info("Importing user hooks...")
                 for loader, name, ispkg in pkgutil.iter_modules([hooks_dir]):
@@ -314,7 +315,7 @@ class Engine:
                     # for later calls.
                     try:
                         self.msg.debug("Importing hook {}...".format(name))
-                        module = loader.find_module(name).load_module(name)
+                        module = importlib.import_module(os.path.basename(hooks_dir) + '.' + name)
                         if hasattr(module, 'init'):
                             module.init(self)
                         self.hooks_available.append(module)


### PR DESCRIPTION
Hooks refuse to load on python version 3.13 because of the error
`AttributeError: 'FileFinder' object has no attribute 'find_module'`

This patch changes find_module to find_spec to fix this issue. I have
tested it using python version 3.8 and 3.13.

Here is the full trace before this patch:

```py
Engine: Reading config files...
Data: Initializing...
libanilist: Initializing...
Data: Using libanilist (anime)
Engine: Parsing redirection file...
Engine: Scanning local library...
Engine: Importing user hooks...
Traceback (most recent call last):
  File "/usr/bin/trackma", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/lib/python3.13/site-packages/trackma/ui/cli.py", line 1071, in main
    main_cmd.start()
    ~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/trackma/ui/cli.py", line 180, in start
    self.engine.start()
    ~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/trackma/engine.py", line 305, in start
    module = loader.find_module(name).load_module(name)
             ^^^^^^^^^^^^^^^^^^
AttributeError: 'FileFinder' object has no attribute 'find_module'
```

Fixes #736.
Duplicates and closes #746.