### PR TITLE
Fix setting "watching" activity

### DIFF
--- a/hooks/presence.py
+++ b/hooks/presence.py
@@ -94,7 +94,7 @@ class DiscordRPC(Thread):
                             details=self._details['details'],
                             state=self._details['state'],
                             start=self._details['start'],
-                            **self._watching
+                            **self._activity
                         )
                     self._update = False
                 time.sleep(1)

--- a/hooks/presence.py
+++ b/hooks/presence.py
@@ -13,7 +13,6 @@ from asyncio import new_event_loop as new_loop
 from asyncio import set_event_loop as set_loop
 from threading import Thread
 
-from importlib.util import find_spec
 from pypresence.client import Client
 from pypresence.exceptions import InvalidID, InvalidPipe
 
@@ -31,8 +30,7 @@ class DiscordRPC(Thread):
     _enabled = False
     _update = False
     regret = True
-    _activity = {} if find_spec('pypresence.types') is None \
-        else {"activity_type": __import__('pypresence.types').ActivityType.WATCHING}
+    _activity_type_kwargs = {}
 
     _rpc = None
     _pid = None
@@ -55,6 +53,13 @@ class DiscordRPC(Thread):
             'img': None,
             'txt': None
         }
+
+        try:
+            from pypresence.types import ActivityType
+
+            self._activity_type_kwargs = {"activity_type": ActivityType.WATCHING}
+        except ImportError:
+            pass
 
     def present(self, engine, start=None, details="Regretting...", state=None, url=None, thumb="icon"):
         """
@@ -94,7 +99,7 @@ class DiscordRPC(Thread):
                             details=self._details['details'],
                             state=self._details['state'],
                             start=self._details['start'],
-                            **self._activity
+                            **self._activity_type_kwargs
                         )
                     self._update = False
                 time.sleep(1)


### PR DESCRIPTION
The change merged in b1c50643420fedde9e13f3063a755e494cf92d42 could not possibly have worked since it's referencing an attribute that was never created. 

I also changed the code to use a more ideomatic try-except block instead of `importlib.find_spec` and `__import__`.

Note that I did not actually test this.