### PR TITLE
Unify open folder

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -979,6 +979,14 @@ class Engine:
         args.append(filename)
         return args
 
+    def open_show_folder(self, show_id):
+        show = self.get_show_info(show_id)
+        filename = self.get_episode_path(show)
+        try:
+            utils.open_folder(os.path.dirname(filename))
+        except OSError:
+            raise utils.EngineError("Could not open folder.")
+
     def queue_clear(self):
         """Clears the data handler queue and discards any unsynced change."""
         return self.data_handler.queue_clear()

--- a/trackma/ui/curses.py
+++ b/trackma/ui/curses.py
@@ -366,27 +366,10 @@ class Trackma_urwid:
 
     def do_openfolder(self):
         item = self._get_selected_item()
-
         try:
-            show = self.engine.get_show_info(item.showid)
-            filename = self.engine.get_episode_path(show)
-            with open(os.devnull, 'wb') as DEVNULL:
-                if sys.platform == 'darwin':
-                    subprocess.Popen(["open",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-                elif sys.platform == 'win32':
-                    subprocess.Popen(["explorer",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-                else:
-                    subprocess.Popen(["xdg-open",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-        except OSError:
-            # xdg-open failed.
-            raise utils.EngineError("Could not open folder.")
-
-        except utils.EngineError:
-            # Show not in library.
-            self.error("No folder found.")
+            self.engine.open_show_folder(item.showid)
+        except utils.EngineError as e:
+            self.error(e.args[0])
 
     def do_play_random(self):
         try:

--- a/trackma/ui/gtk/window.py
+++ b/trackma/ui/gtk/window.py
@@ -573,29 +573,10 @@ class TrackmaWindow(Gtk.ApplicationWindow):
             Gtk.show_uri(None, show['url'], Gdk.CURRENT_TIME)
 
     def _open_folder(self, show_id):
-        show = self._engine.get_show_info(show_id)
         try:
-            filename = self._engine.get_episode_path(show)
-            with open(os.devnull, 'wb') as DEVNULL:
-                if sys.platform == 'darwin':
-                    subprocess.Popen(["open", os.path.dirname(filename)],
-                                     stdout=DEVNULL,
-                                     stderr=DEVNULL)
-                elif sys.platform == 'win32':
-                    subprocess.Popen(["explorer", os.path.dirname(filename)],
-                                     stdout=DEVNULL,
-                                     stderr=DEVNULL)
-                else:
-                    subprocess.Popen(["xdg-open", os.path.dirname(filename)],
-                                     stdout=DEVNULL,
-                                     stderr=DEVNULL)
-        except OSError:
-            # xdg-open failed.
-            raise utils.EngineError("Could not open folder.")
-
-        except utils.EngineError:
-            # Show not in library.
-            self._error_dialog_idle("No folder found.")
+            self._engine.open_show_folder(show_id)
+        except utils.EngineError as e:
+            self._error_dialog_idle(e.args[0])
 
     def _copy_title(self, show_id):
         show = self._engine.get_show_info(show_id)

--- a/trackma/ui/qt/mainwindow.py
+++ b/trackma/ui/qt/mainwindow.py
@@ -1183,26 +1183,10 @@ class MainWindow(QMainWindow):
             self.ws_changed_show(show, altname=new_altname)
 
     def s_open_folder(self):
-        show = self.worker.engine.get_show_info(self.selected_show_id)
         try:
-            filename = self.worker.engine.get_episode_path(show)
-            with open(os.devnull, 'wb') as DEVNULL:
-                if sys.platform == 'darwin':
-                    subprocess.Popen(["open",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-                elif sys.platform == 'win32':
-                    subprocess.Popen(["explorer",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-                else:
-                    subprocess.Popen(["xdg-open",
-                                      os.path.dirname(filename)], stdout=DEVNULL, stderr=DEVNULL)
-        except OSError:
-            # xdg-open failed.
-            raise utils.EngineError("Could not open folder.")
-
-        except utils.EngineError:
-            # Show not in library.
-            self.error("No folder found.")
+            self.worker.engine.open_show_folder(self.selected_show_id)
+        except utils.EngineError as e:
+            self.error(e.args[0])
 
     def s_retrieve(self):
         queue = self.worker.engine.get_queue()

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -434,6 +434,15 @@ def redirect_show(show_tuple, redirections, tracker_list):
     return show_tuple
 
 
+def open_folder(path):
+    if sys.platform == 'darwin':
+        spawn_process(["open", path])
+    elif sys.platform == 'win32':
+        spawn_process(["explorer", path])
+    else:
+        spawn_process(["xdg-open", path])
+
+
 _spawned_processes = []
 
 

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -25,8 +25,6 @@ import shutil
 import subprocess
 import sys
 import time
-import urllib.error
-import urllib.request
 import uuid
 from enum import Enum, auto
 
@@ -314,7 +312,7 @@ def sync_file(fname, sync_url):
     if not sync_url:
         return False
 
-    import urllib
+    import urllib.request
     import socket
 
     try:


### PR DESCRIPTION
Continues the work of #727 but in a simpler fashion (as suggested in the review comments).

Since the code is identical for all UIs with the exception of determining the show id and error reporting, we move the common functionality to the engine and to a new small helper method in utils that defers to `spawn_process` (to re-use our already existing code to prevent zombie processes).

Because I had problems with the double-fork code for xdg-open here (unlike with mpv when playing episodes), I switched it to a different method that launches subprocesses normally via subprocess but also added a daemon thread to poll our created subprocesses and thus prevent them from remaining as zombies on \*NIX OSes.

Supersedes and closes #727
Fixes #525
Fixes #508