### PR TITLE
Module for loading hooks

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -31,6 +31,7 @@ from trackma import messenger
 from trackma import utils
 from trackma.extras import redirections
 from trackma.parser import get_parser_class
+from trackma import hooks
 
 
 class Engine:
@@ -302,22 +303,12 @@ class Engine:
 
         # Load hook files
         if self.config['use_hooks']:
-            hooks_dir = utils.to_config_path('hooks')
-            if os.path.isdir(hooks_dir):
-                import importlib.util
-                import pkgutil
-
+            if hooks.init():
                 self.msg.info("Importing user hooks...")
-                for finder, name, _ in pkgutil.iter_modules([hooks_dir]):
-                    # List all the hook files in the hooks folder, import them
-                    # and call the init() function if they have them
-                    # We build the list "hooks available" with the loaded modules
-                    # for later calls.
+                for name in hooks.iter():
                     try:
                         self.msg.debug("Importing hook {}...".format(name))
-                        module_spec = finder.find_spec(name)
-                        module = importlib.util.module_from_spec(module_spec)
-                        module_spec.loader.exec_module(module)
+                        module = hooks.load(name)
                         if hasattr(module, 'init'):
                             module.init(self)
                         self.hooks_available.append(module)

--- a/trackma/hooks.py
+++ b/trackma/hooks.py
@@ -1,0 +1,33 @@
+__path__ = []
+
+
+def iter():
+    """Return an iterator over the modules in __path__."""
+    if not __path__:
+        return ()
+
+    from pkgutil import iter_modules
+    return (name for _, name, _ in iter_modules(__path__))
+
+
+def load(name, attr=None):
+    if not __path__:
+        raise ImportError(f"Cannot load hook '{name}'")
+
+    from importlib import import_module
+    return import_module(f'trackma.hooks.{name}')
+
+
+def init():
+    from os import path
+    from trackma import utils
+
+    hooks = utils.to_config_path('hooks')
+    if not path.exists(hooks):
+        return False
+
+    if not hooks in __path__:
+        __path__.append(hooks)
+    return True
+
+# vim: et:ts=4:ft=python3


### PR DESCRIPTION
- **hooks: Implement hook loader module**
- **engine: Use trackma.hooks to load hooks**

This approach seems cleaner to me than #769, and also has the added benefit of not breaking unless python ignores `__path__`
