### PR TITLE
feat: autoplay next episode support

### DIFF
--- a/hooks/example.py
+++ b/hooks/example.py
@@ -31,6 +31,14 @@ def playing(engine, show, is_playing, episode):
     pass
 
 
+def finished(engine, show, episode):
+    """This is called when a player is closed after successfully finishing a show.
+    `show`: dictionary with the information of the show
+    `episode`: episode number
+    """
+    pass
+
+
 def show_added(engine, show):
     """This is called after an item has been added to the local list.
     `show` contains the item information as a dictionary."""

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -70,6 +70,7 @@ class Engine:
                'sync_complete':     None,
                'queue_changed':     None,
                'playing':           None,
+               'finished': None,
                'prompt_for_update': None,
                'prompt_for_add':    None,
                'tracker_state':     None,
@@ -173,6 +174,8 @@ class Engine:
                     self.msg.info(f"Finished watching {show['title']}.")
             except utils.EngineError as e:
                 self.msg.warn(f"Could not autoplay next episode: {e}")
+
+        self._emit_signal('finished', show, episode)
 
     def _tracker_unrecognised(self, show, episode):
         if self.config['tracker_not_found_prompt']:

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -159,6 +159,9 @@ class Engine:
             except utils.TrackmaError as e:
                 self.msg.warn("Can't update episode: {}".format(e))
 
+    def _tracker_finished(self, show, episode):
+        pass
+
     def _tracker_unrecognised(self, show, episode):
         if self.config['tracker_not_found_prompt']:
             self._emit_signal('prompt_for_add', show, episode)
@@ -344,6 +347,7 @@ class Engine:
                 self.tracker.connect_signal('removed', self._tracker_removed)
                 self.tracker.connect_signal('playing', self._tracker_playing)
                 self.tracker.connect_signal('update', self._tracker_update)
+                self.tracker.connect_signal('finish', self._tracker_finished)
                 self.tracker.connect_signal(
                     'unrecognised', self._tracker_unrecognised)
                 self.tracker.connect_signal('state', self._tracker_state)

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -160,7 +160,19 @@ class Engine:
                 self.msg.warn("Can't update episode: {}".format(e))
 
     def _tracker_finished(self, show, episode):
-        pass
+
+        # Attempt autoplay next episode
+        if self.config['autoplay_next']:
+            try:
+                next_episode = episode + 1
+                play_args = self.play_episode(show, next_episode)
+                if play_args:
+                    self.msg.info(f"Autoplaying next episode {next_episode} of {show['title']}")
+                    utils.spawn_process(play_args)
+                else:
+                    self.msg.info(f"Finished watching {show['title']}.")
+            except utils.EngineError as e:
+                self.msg.warn(f"Could not autoplay next episode: {e}")
 
     def _tracker_unrecognised(self, show, episode):
         if self.config['tracker_not_found_prompt']:

--- a/trackma/tracker/tracker.py
+++ b/trackma/tracker/tracker.py
@@ -44,6 +44,7 @@ class TrackerBase(object):
         'removed': None,
         'update': None,
         'unrecognised': None,
+        'finish': None
     }
 
     def __init__(self, messenger, tracker_list, config, watch_dirs, redirections=None):
@@ -224,6 +225,11 @@ class TrackerBase(object):
                 # Video didn't get to update phase before it was closed
                 if self.last_state == utils.Tracker.PLAYING and not self.last_updated:
                     self.msg.info('Player was closed before update.')
+                # Video was playing and timer reached zero but player just closed
+                elif self.last_state == utils.Tracker.PLAYING and self.last_updated and self.last_show_tuple:
+                    self.msg.debug('Player closed after update timer completed.')
+                    show, episode = self.last_show_tuple
+                    self._emit_signal('finish', show, episode)
             # There's a new video playing but the regex didn't recognize the format
             elif state == utils.Tracker.UNRECOGNIZED:
                 self.msg.warn('Found video but the file name format couldn\'t be recognized.')

--- a/trackma/ui/cli.py
+++ b/trackma/ui/cli.py
@@ -70,6 +70,7 @@ class Trackma_cmd(command.Cmd):
     sortedlist = []
     needed_args = {
         'altname':      (1, 2),
+        'autoplay':     (0,1),
         'filter':       (0, 1),
         'sort':         1,
         'mediatype':    (0, 1),
@@ -504,6 +505,31 @@ class Trackma_cmd(command.Cmd):
                 print("Not started")
         except utils.TrackmaError as e:
             self.display_error(e)
+
+    def do_autoplay(self, args):
+        """
+        Automatically play the next episode when the current one ends.
+        View the current autoplay status with no arguments.
+        :optparam on|off Enable or disable autoplay mode.
+
+        :usage: autoplay <on|off>
+        """
+
+        if args:
+            if args[0].lower() == "on":
+                self.engine.set_config("autoplay_next", True)
+                print("Autoplay enabled.")
+            elif args[0].lower() == "off":
+                self.engine.set_config("autoplay_next", False)
+                print("Autoplay disabled.")
+            else:
+                print("Invalid argument. Use 'on' or 'off'.")
+        else:
+            print(
+                "Autoplay is {}.".format(
+                    "enabled" if self.engine.get_config("autoplay_next") else "disabled"
+                )
+            )
 
     def do_play(self, args):
         """

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -588,6 +588,7 @@ config_defaults = {
     'auto_status_change': True,
     'auto_status_change_if_scored': True,
     'auto_date_change': True,
+    'autoplay_next': False,
     'tracker_type': "auto",
     'plex_host': "localhost",
     'plex_port': "32400",


### PR DESCRIPTION
- **add autoplay mode handling in cli and in config**
- **call new signal "finish" when player is closed after an "update"**
- **handle the new finish signal in engine**
- **add autoplay functionality in engine**
- **add support for "finished" hook**

Add new feature to autoplay next episode.

Testing and working for MPRIS and lsof. I couldn't get inotify based tracker to work at all, so i couldnt test that.

## Inspiration

I've always wanted to use trackma to be my only anime watching app (as I download almost all of my anime using ani-cli, but also have an ani-cli hook in trackma, so I never really have a reason to not use it). But my only pain point is that it does not autoplay next episode, which is not helpful for "binging".

Of course I can use autoload.lua script for mpv, but I wanted a feature in trackma itself.

## Working

I added a new signal called "finish". It is triggered whenever a player is closed after successfully watching an episode, i.e. when the player is open for atleast "tracker_update_wait_s" seconds.

Then I've added a new option called "autoplay_next" (defaults to false), which can be toggled at runtime.

The engine reacts to this signal, and plays the episode + 1 after checking runtime autoplay_next

Also added hook support for this finish signal.

# TODO

The autoplay toggle is not yet ready for qt, gtk and curses interfaces. It is currently only available for the cli interface.

I prefer to have something like a switch in the interfaces below the play button (in the home page) to toggle autoplay on and off.

I do not know how to do this in the interfaces, I will need to look that up. In the meantime, if anyone is willing to help, it would be great.

Please let me know if i need to change anything in the code, or if you have any suggestions.