### PR TITLE
feat: ani-skip integration

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from trackma import data
 from trackma import messenger
 from trackma import utils
-from trackma.extras import redirections
+from trackma.extras import redirections, ani_skip
 from trackma.parser import get_parser_class
 
 
@@ -987,6 +987,10 @@ class Engine:
 
         if not args[0]:
             raise utils.EngineError('Player not found, check your config.json')
+
+        if self.config['ani_skip']:
+            self.msg.debug("Fetching chapters from ani-skip")
+            args.append(ani_skip.get_args(playep, show, self.config['player']))
 
         args.append(filename)
         return args

--- a/trackma/extras/ani_skip.py
+++ b/trackma/extras/ani_skip.py
@@ -1,0 +1,131 @@
+# This file is part of Trackma.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from os.path import basename
+import requests
+import tempfile
+
+
+def get_args(
+    episode, show, player_path, types=["op", "ed", "mixed-op", "mixed-ed", "recap"]
+):
+
+    SUPPORTED_PLAYERS = ["mpv"]
+    CHAPTERS_FILE_ARG = {"mpv": "--chapters-file"}
+    ANI_SKIP_ENDPOINT = "https://api.aniskip.com/v2/skip-times/{idMal}/{episode}"
+
+    player = basename(player_path)
+
+    # Skip if the player does not support ffmetadata file
+    if player not in SUPPORTED_PLAYERS:
+        return None
+
+    idMal = _idMal(show)
+
+    if idMal is None:
+        return None
+
+    params = {"types": types, "episodeLength": 0}
+    headers = {"accept": "application/json"}
+
+    args = []
+
+    try:
+        response = requests.get(
+            ANI_SKIP_ENDPOINT.format(idMal=idMal, episode=episode),
+            params=params,
+            headers=headers,
+        )
+
+        if response.status_code == 200:
+            results = response.json().get("results")
+            args.append(
+                CHAPTERS_FILE_ARG[player] + "=" + _create_chapters_file(results)
+            )
+
+    except requests.RequestException as e:
+        return None
+
+    return "".join(args)
+
+
+def _create_chapters_file(timestamps):
+    """
+    FFMetadata file generator
+    Arguments: timestamps: list from ani-skip api
+    Returns: Filename of the generated tmpfile
+
+    https://api.aniskip.com/api-docs
+    https://ffmpeg.org/ffmpeg-formats.html#metadata
+    """
+
+    CHAPTER_TYPES = {"op": "Opening", "ed": "Ending", "recap": "Recap"}
+    TIMEBASE = "1/1000"
+
+    chapters = [";FFMETADATA1"]
+
+    episode_start = None
+    episode_end = None
+
+    for timestamp in timestamps:
+
+        # If the skip type is not recognised, skip it
+        if timestamp.get("skipType", None) not in CHAPTER_TYPES:
+            continue
+
+        start = int(float(timestamp["interval"]["startTime"]) * 1000)
+        end = int(float(timestamp["interval"]["endTime"]) * 1000)
+        title = CHAPTER_TYPES[timestamp["skipType"]]
+
+        if title == CHAPTER_TYPES["op"]:
+            episode_start = end
+        elif title == CHAPTER_TYPES["ed"]:
+            episode_end = start
+
+        chapters.extend(
+            [
+                "[CHAPTER]",
+                f"TIMEBASE={TIMEBASE}",
+                f"START={start}",
+                f"END={end}",
+                f"TITLE={title}",
+            ]
+        )
+
+    episode_content = [
+        "[CHAPTER]",
+        f"TIMEBASE={TIMEBASE}",
+        "TITLE=Episode",
+        f"START={episode_start if episode_start is not None else 0}",
+    ]
+    episode_content.append(
+        f"END={episode_end if episode_end is not None else (episode_start if episode_start is not None else 0)}"
+    )
+
+    chapters.extend(episode_content)
+
+    # Create a newline separated string from the built chapters list
+    with tempfile.NamedTemporaryFile(
+        delete=False, mode="w", encoding="utf-8"
+    ) as tmp_file:
+        tmp_file.write("\n".join(chapters) + "\n")
+        tmp_filename = tmp_file.name
+
+    return tmp_filename
+
+
+def _idMal(show):
+    return show.get("idMal", None)

--- a/trackma/lib/libanilist.py
+++ b/trackma/lib/libanilist.py
@@ -252,6 +252,7 @@ fragment mediaListEntry on MediaList {
   completedAt { year month day }
   media {
     id
+    idMal
     title { userPreferred romaji english native }
     synonyms
     coverImage { large medium }
@@ -294,6 +295,7 @@ fragment mediaListEntry on MediaList {
                 showdata = {
                     'my_id': item['id'],
                     'id': showid,
+                    'idMal': media['idMal'],
                     'title': media['title']['userPreferred'],
                     'aliases': self._get_aliases(media),
                     'type': self._translate_type(media['format']),
@@ -424,6 +426,7 @@ fragment mediaListEntry on MediaList {
         query = '''query ($id: Int!, $type: MediaType) {
   Media(id: $id, type: $type) {
       id
+      idMal
       title { userPreferred romaji english native }
       coverImage { medium large }
       format
@@ -459,6 +462,7 @@ fragment mediaListEntry on MediaList {
 
         info.update({
             'id': showid,
+            'idMal': item['idMal'],
             'title': item['title']['userPreferred'],
             'total': self._c(item[self.total_str]),
             'aliases': self._get_aliases(item),

--- a/trackma/lib/libmal.py
+++ b/trackma/lib/libmal.py
@@ -275,6 +275,7 @@ class libmal(lib):
                 shows[showid] = utils.show()
                 shows[showid].update({
                     'id': showid,
+                    'idMal': showid,
                     'title': item['node']['title'],
                     'url': "https://myanimelist.net/%s/%d" % (self.mediatype, showid),
                     'aliases': self._get_aliases(item['node']),
@@ -376,6 +377,7 @@ class libmal(lib):
         
         info.update({
             'id': showid,
+            'idMal': item['idMal'],
             'title': item['title'],
             'url': "https://myanimelist.net/%s/%d" % (self.mediatype, showid),
             'aliases': self._get_aliases(item),

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -609,6 +609,7 @@ config_defaults = {
     'redirections_time': 1,
     'use_hooks': True,
     'title_parser': 'aie',
+    'ani_skip': False
 }
 
 userconfig_defaults = {


### PR DESCRIPTION
- **libanilist: add idMal info**
- **libmal: add idMal info**
- **add ani_skip config option**
- **add ani-skip integration**

Add ani-skip integration.

ani-skip is a database storing start and end times for anime intros,ending,recap,etc.
This patch allows FFMetadata file supported players to utilize the api to add chapter markers for Opening, Ending and Recap.

Adds a new config key ani_skip (bool) to use ani-skip chapter appending.

Since ani-skip stores the skip-times based on MAL id, we require getting MAL ID from various trackers. Currently, Anilist (implemented), Shikimori (not implemented), and MAL support returning MAL ID using the API. I haven't found anything in Kitsu docs that might resembles MAL ID but i may be wrong.

The `show` variable has an extra key `malId` which is used to get the skip times from the api.

TODO: Please add support for returning MAL ID from Shikimori and Kitsu in libskihimori.py and libkitsu.py. I haven't implemented it.

Let me know if there are any design flaws. I will correct them.
