### PR TITLE
Fix type definition mismatch in progressChanged signal

### DIFF
--- a/trackma/ui/qt/models.py
+++ b/trackma/ui/qt/models.py
@@ -38,7 +38,7 @@ class ShowListModel(QtCore.QAbstractTableModel):
 
     date_format = "%Y-%m-%d"
 
-    progressChanged = QtCore.pyqtSignal(QtCore.QVariant, int)
+    progressChanged = QtCore.pyqtSignal(QtCore.QVariant, float)
     scoreChanged = QtCore.pyqtSignal(QtCore.QVariant, float)
 
     def __init__(self, parent=None, palette=None):


### PR DESCRIPTION
I have spotted a type param mismatch in the QtCore.pyqtSignal call at trackma/ui/qt/models.py for the progressChanged signal. The C type should be "float" not "int" because the value that is passed to it is a float given by ShowsTableDelegate.setModelData at trackma/ui/qt/delegates.py that calls a QWidget.value() that returns a float.

Fixes #794 

