### PR TITLE
Revert "data: Safely store data on disk"

### DIFF
--- a/trackma/data.py
+++ b/trackma/data.py
@@ -507,10 +507,7 @@ class Data:
 
     def _save_cache(self):
         self.msg.debug("Saving cache...")
-        try:
-            utils.save_data(self.showlist, self.cache_file)
-        except OSError as e:
-            self.msg.error(f"Unable to save cache: {e}")
+        utils.save_data(self.showlist, self.cache_file)
 
     def _load_info(self):
         self.msg.debug("Reading info DB...")
@@ -518,10 +515,7 @@ class Data:
 
     def _save_info(self):
         self.msg.debug("Saving info DB...")
-        try:
-            utils.save_data(self.infocache, self.info_file)
-        except OSError as e:
-            self.msg.error(f"Unable to save info: {e}")
+        utils.save_data(self.infocache, self.info_file)
 
     def _load_userconfig(self):
         self.msg.debug("Reading userconfig...")
@@ -530,10 +524,7 @@ class Data:
 
     def _save_userconfig(self):
         self.msg.debug("Saving userconfig...")
-        try:
-            utils.save_config(self.userconfig, self.userconfig_file)
-        except OSError as e:
-            self.msg.error(f"Unable to save userconfig: {e}")
+        utils.save_config(self.userconfig, self.userconfig_file)
 
     def _load_queue(self):
         self.msg.debug("Reading queue...")
@@ -541,10 +532,7 @@ class Data:
 
     def _save_queue(self):
         self.msg.debug("Saving queue...")
-        try:
-            utils.save_data(self.queue, self.queue_file)
-        except OSError as e:
-            self.msg.error(f"Unable to save queue: {e}")
+        utils.save_data(self.queue, self.queue_file)
 
     def _load_meta(self):
         self.msg.debug("Reading metadata...")
@@ -553,10 +541,7 @@ class Data:
 
     def _save_meta(self):
         self.msg.debug("Saving metadata...")
-        try:
-            utils.save_data(self.meta, self.meta_file)
-        except OSError as e:
-            self.msg.error(f"Unable to save metadata: {e}")
+        utils.save_data(self.meta, self.meta_file)
 
     def download_data(self):
         """Downloads the remote list and overwrites the cache"""

--- a/trackma/messenger.py
+++ b/trackma/messenger.py
@@ -55,10 +55,11 @@ class Messenger:
     def warn(self, *msgs):
         self._call_handler(msgs, TYPE_WARN)
 
-    def exception(self, exc_info):
+    def exception(self, *msgs):
         if not self._handler:
             return
+        cn, exc_info = self._parse_msgs(msgs[:2])
         exc_type, exc_value, exc_traceback = exc_info
         for block in traceback.format_exception(exc_type, exc_value, exc_traceback):
             for line in block.splitlines():
-                self._handler(self.classname, TYPE_DEBUG, line)
+                self._handler(cn, TYPE_DEBUG, line)

--- a/trackma/tracker/mpris.py
+++ b/trackma/tracker/mpris.py
@@ -240,8 +240,7 @@ class MprisTracker(tracker.TrackerBase):
             try:
                 await asyncio.gather(*tasks)
             except Exception:
-                self.msg.error("Error in dbus watchers; cleaning up")
-                self.msg.exception(sys.exc_info())
+                self.msg.exception("Error in dbus watchers; cleaning up", sys.exc_info())
                 for task in tasks:
                     task.cancel()
                 await asyncio.gather(*tasks)

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -197,7 +197,7 @@ def parse_config(filename, default):
     config = copy.copy(default)
 
     try:
-        with open(filename, encoding="utf-8") as configfile:
+        with open(filename) as configfile:
             loaded_config = json.load(configfile)
             if 'colors' in config and 'colors' in loaded_config:
                 # Need to prevent nested dict from being overwritten with an incomplete dict
@@ -222,19 +222,9 @@ def save_config(config_dict, filename):
     if not os.path.isdir(path):
         os.mkdir(path)
 
-    # Write to a temporary file first to ensure there is enough space
-    # and we do not end up writing incomplete files.
-    # Because configuration files are symlinked sometimes,
-    # we do not unlink the original file and move the temporary file.
-    # Instead, we copy the temporary file's contents.
-    # The size of the config file is unlikely to change significantly anyway.
-    tmp_filename = filename + '.tmp'
-    with open(tmp_filename, 'w', encoding="utf-8") as configfile:
-        json.dump(config_dict, configfile, sort_keys=True,
-                  indent=4, separators=(',', ': '))
-
-    shutil.copyfile(tmp_filename, filename)
-    os.unlink(tmp_filename)
+    with open(filename, 'wb') as configfile:
+        configfile.write(json.dumps(config_dict, sort_keys=True,
+                                    indent=4, separators=(',', ': ')).encode('utf-8'))
 
 
 def load_data(filename):
@@ -243,19 +233,12 @@ def load_data(filename):
 
 
 def save_data(data, filename):
-    # Write to a temporary file first to ensure there is enough space
-    # and we do not end up writing incomplete files.
-    # Unlink the old and move over the temporary file afterwards.
-    # Do this in the same folder to reduce the disk of crossing file systems.
-    tmp_filename = filename + '.tmp'
-    with open(tmp_filename, 'wb') as datafile:
+    with open(filename, 'wb') as datafile:
         pickle.dump(data, datafile, protocol=2)
-    os.unlink(filename)
-    os.rename(tmp_filename, filename)
 
 
 def log_error(msg):
-    with open(to_data_path('error.log'), 'a', encoding="utf-8") as logfile:
+    with open(to_data_path('error.log'), 'a') as logfile:
         logfile.write(msg)
 
 


### PR DESCRIPTION
Reverts z411/trackma#789

This is not working. It's failing with a Not Found system error, and also the messenger does not have an `error()` method. #789 must be reviewed.