### PR TITLE
Add "Prefer media title" setting (mpris only, for now)

### DIFF
--- a/trackma/tracker/mpris.py
+++ b/trackma/tracker/mpris.py
@@ -154,7 +154,7 @@ class Player:
 
     @property
     def filename(self):
-        if self.title and len(self.title) > 5:
+        if self.config['tracker_prefer_media_title'] and self.title and len(self.title) > 5:
             return self.title
         elif self.url:
             url = urllib.parse.unquote_plus(self.url)

--- a/trackma/ui/qt/settings.py
+++ b/trackma/ui/qt/settings.py
@@ -92,6 +92,7 @@ class SettingsDialog(QDialog):
         self.tracker_update_prompt = QCheckBox()
         self.tracker_not_found_prompt = QCheckBox()
         self.tracker_ignore_not_next = QCheckBox()
+        self.tracker_prefer_media_title = QCheckBox()
 
         g_media_layout.addRow('Enable tracker', self.tracker_enabled)
         g_media_layout.addRow('Tracker type', self.tracker_type)
@@ -108,6 +109,7 @@ class SettingsDialog(QDialog):
                               self.tracker_not_found_prompt)
         g_media_layout.addRow('Ignore if not next episode',
                               self.tracker_ignore_not_next)
+        g_media_layout.addRow('Prefer media title', self.tracker_prefer_media_title)
 
         g_media.setLayout(g_media_layout)
 
@@ -523,6 +525,8 @@ class SettingsDialog(QDialog):
             engine.get_config('tracker_not_found_prompt'))
         self.tracker_ignore_not_next.setChecked(
             engine.get_config('tracker_ignore_not_next'))
+        self.tracker_prefer_media_title.setChecked(
+            engine.get_config('tracker_prefer_media_title'))
 
         self.title_parser.setCurrentIndex(max(0, title_parser))
         self.player.setText(engine.get_config('player'))
@@ -632,6 +636,8 @@ class SettingsDialog(QDialog):
                           self.tracker_not_found_prompt.isChecked())
         engine.set_config('tracker_ignore_not_next',
                           self.tracker_ignore_not_next.isChecked())
+        engine.set_config('tracker_prefer_media_title',
+                          self.tracker_prefer_media_title.isChecked())
 
         engine.set_config('title_parser',          self.title_parser.itemData(
             self.title_parser.currentIndex()))

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -578,6 +578,7 @@ config_defaults = {
     'tracker_interval': 10,
     'tracker_process': 'mplayer|mplayer2|mpv',
     'tracker_ignore_not_next': True,
+    'tracker_prefer_media_title': False,
     'autoretrieve': 'days',
     'autoretrieve_days': 3,
     'autosend': 'minutes',


### PR DESCRIPTION
The current mpris implementation prefers the media title as reported by the respective dbus provider (i.e. the player), but personally I found the file name to be much more accurate when matching against my library, which is why I've basically had this feature disabled locally ever since I rewrote the mpris tracker. As a result and from this experience, the setting is disabled by default.

I always wanted to upstream this but not without also making it configurable, so here goes.

This feature is not complete, however, because:

1. I don't understand the Gtk UI (never worked with it), so I didn't add it there. I assume I'd need to use a GUI editor to get the layouting right.
1. For file-based trackers, we would probably want to add something that can read media info from the files. I was planning to use `mediainfo --Output=JSON` for this, but it seems questionable whether this is available on the PATH for Windows users. Do we need to make the path configurable?
1. What about other trackers? Do Jellyfin or Plex even support retrieving the media's file name? If supported, does the default of preferring the file name make sense for them?

Edit: Jellyfin seems to support it (via https://github.com/z411/trackma/issues/552#issuecomment-799649524). 

---

I also implemented the `library_full_path` setting because that was also missing.

Related: #751
Related: #552 