### PR TITLE
Fix AttributeError of QSystemTrayIcon

### DIFF
--- a/trackma/ui/qt/mainwindow.py
+++ b/trackma/ui/qt/mainwindow.py
@@ -993,7 +993,7 @@ class MainWindow(QMainWindow):
                 self.show()
 
     def s_tray_clicked(self, reason):
-        if reason == QSystemTrayIcon.Trigger:
+        if reason == QSystemTrayIcon.ActivationReason.Trigger:
             self.s_hide()
 
     def s_busy(self):


### PR DESCRIPTION
`Trackma` (Qt) crashes when clicking on tray icon.
I found that the `QSystemTrayIcon.Trigger` should be corrected to `QSystemTrayIcon.ActivationReason.Trigger`.
I have tested it locally and now minimise to tray works without any problem.

**Edit**: You can find a full name `QSystemTrayIcon.ActivationReason.Trigger` mentioned in documentation:
[class ActivationReason | PySide6.QtWidgets.QSystemTrayIcon @ Qt for Python documentation](https://doc.qt.io/qtforpython-6/PySide6/QtWidgets/QSystemTrayIcon.html#:~:text=QSystemTrayIcon%2EActivationReason%2ETrigger)