### PR TITLE
Qt: Fix non-functional "Invert" checkbox

### DIFF
--- a/trackma/ui/qt/mainwindow.py
+++ b/trackma/ui/qt/mainwindow.py
@@ -334,7 +334,7 @@ class MainWindow(QMainWindow):
         colkeys = ', '.join(sorted(self.column_keys.keys()))
         self.show_filter.setToolTip(filter_tooltip + colkeys + '.')
         self.show_filter_invert = QCheckBox()
-        self.show_filter_invert.stateChanged.connect(self.s_filter_changed)
+        self.show_filter_invert.stateChanged.connect(self.s_filter_invert_changed)
         self.show_filter_casesens = QCheckBox()
         self.show_filter_casesens.stateChanged.connect(self.s_filter_changed)
 
@@ -1063,8 +1063,10 @@ class MainWindow(QMainWindow):
             self.view.model().setFilterCaseSensitivity(QtCore.Qt.CaseSensitivity.CaseSensitive)
         else:
             self.view.model().setFilterCaseSensitivity(QtCore.Qt.CaseSensitivity.CaseInsensitive)
-        self.view.model().setFilterInvert(self.show_filter_invert.isChecked())
         self.view.model().setFilterFixedString(expression)
+
+    def s_filter_invert_changed(self):
+        self.view.model().setFilterInvert(self.show_filter_invert.isChecked())
 
     def s_plus_episode(self):
         self._busy(True)

--- a/trackma/ui/qt/models.py
+++ b/trackma/ui/qt/models.py
@@ -405,6 +405,7 @@ class ShowListProxy(QtCore.QSortFilterProxyModel):
 
     def setFilterInvert(self, invert):
         self.filter_invert = invert
+        self.invalidateFilter()
 
     def filterAcceptsRow(self, source_row, source_parent):
         if self.filter_status is not None and self.sourceModel().showlist[source_row]['my_status'] != self.filter_status:


### PR DESCRIPTION
Fixes #816 

QRegularExpression does not have a pattern option for this so I used already overridden filterAcceptsRow method.