### PR TITLE
Fix Jellyfin tracker request issues

### DIFF
--- a/trackma/tracker/jellyfin.py
+++ b/trackma/tracker/jellyfin.py
@@ -36,7 +36,11 @@ class JellyfinTracker(tracker.TrackerBase):
     def __init__(self, messenger, tracker_list, config, watch_dirs, redirections=None):
         self.config = config
 
-        self.host_port = self.config['jellyfin_host']+":"+self.config['jellyfin_port']
+        self.host_port = "{protocol}://{host}:{port}".format(
+            host=self.config['jellyfin_host'],
+            port=self.config['jellyfin_port'],
+            protocol='https' if self.config['jellyfin_ssl'] else 'http'
+        )
         self.api_key = self.config['jellyfin_api_key']
         self.username = self.config['jellyfin_user']
 

--- a/trackma/ui/gtk/data/settingswindow.ui
+++ b/trackma/ui/gtk/data/settingswindow.ui
@@ -679,10 +679,24 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="checkbox_jellyfin_ssl">
+                                <property name="label" translatable="yes">Use SSL</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkLabel">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Password</property>
+                                <property name="label" translatable="yes">API key</property>
                                 <property name="xalign">0</property>
                               </object>
                               <packing>

--- a/trackma/ui/gtk/settingswindow.py
+++ b/trackma/ui/gtk/settingswindow.py
@@ -70,6 +70,7 @@ class SettingsWindow(Gtk.Window):
     radio_tracker_jellyfin = Gtk.Template.Child()
     entry_jellyfin_host = Gtk.Template.Child()
     spin_jellyfin_port = Gtk.Template.Child()
+    checkbox_jellyfin_ssl = Gtk.Template.Child()
     entry_jellyfin_username = Gtk.Template.Child()
     entry_jellyfin_api_key = Gtk.Template.Child()
 
@@ -194,6 +195,7 @@ class SettingsWindow(Gtk.Window):
             self.engine.get_config('jellyfin_host'))
         self.spin_jellyfin_port.set_value(
             int(self.engine.get_config('jellyfin_port')))
+        self.checkbox_jellyfin_ssl.set_active(self.engine.get_config('jellyfin_ssl'))
         self.entry_jellyfin_username.set_text(
             self.engine.get_config('jellyfin_user'))
         self.entry_jellyfin_api_key.set_text(
@@ -335,6 +337,7 @@ class SettingsWindow(Gtk.Window):
     def _enable_jellyfin(self, enable):
         self.entry_jellyfin_host.set_sensitive(enable)
         self.spin_jellyfin_port.set_sensitive(enable)
+        self.checkbox_jellyfin_ssl.set_sensitive(enable)
         self.entry_jellyfin_username.set_sensitive(enable)
         self.entry_jellyfin_api_key.set_sensitive(enable)
 
@@ -389,6 +392,7 @@ class SettingsWindow(Gtk.Window):
             'plex_passwd', self.entry_plex_password.get_text())
         self.engine.set_config(
             'jellyfin_host', self.entry_jellyfin_host.get_text())
+        self.engine.set_config('jellyfin_ssl', self.checkbox_jellyfin_ssl.get_active())
         self.engine.set_config('jellyfin_port', str(
             int(self.spin_jellyfin_port.get_value())))
         self.engine.set_config(

--- a/trackma/ui/qt/settings.py
+++ b/trackma/ui/qt/settings.py
@@ -149,6 +149,7 @@ class SettingsDialog(QDialog):
         g_jellyfin.setFlat(True)
         self.jellyfin_host = QLineEdit()
         self.jellyfin_port = QLineEdit()
+        self.jellyfin_ssl = QCheckBox()
         self.jellyfin_user = QLineEdit()
         self.jellyfin_api_key = QLineEdit()
 
@@ -159,12 +160,13 @@ class SettingsDialog(QDialog):
                                 0, 1, 1, 1)
         g_jellyfin_layout.addWidget(self.jellyfin_port,
                                 0, 2, 1, 2)
+        g_jellyfin_layout.addWidget(QLabel('Use SSL'), 1, 0, 1, 1)
+        g_jellyfin_layout.addWidget(self.jellyfin_ssl, 1,2,1,1)
         g_jellyfin_layout.addWidget(
-            QLabel('API and User'),                   1, 0, 1, 1)
+            QLabel('API and User'),                   2, 0, 1, 1)
         g_jellyfin_layout.addWidget(self.jellyfin_api_key,
-                                1, 1, 1, 1)
-        g_jellyfin_layout.addWidget(self.jellyfin_user,
-                                1, 2, 1, 2)
+                                2, 1, 1, 1)
+        g_jellyfin_layout.addWidget(self.jellyfin_user, 2, 2, 1, 2)
 
         g_jellyfin.setLayout(g_jellyfin_layout)
 
@@ -537,6 +539,7 @@ class SettingsDialog(QDialog):
 
         self.jellyfin_host.setText(engine.get_config('jellyfin_host'))
         self.jellyfin_port.setText(engine.get_config('jellyfin_port'))
+        self.jellyfin_ssl.setChecked(engine.get_config('jellyfin_ssl'))
         self.jellyfin_user.setText(engine.get_config('jellyfin_user'))
         self.jellyfin_api_key.setText(engine.get_config('jellyfin_api_key'))
 
@@ -647,6 +650,7 @@ class SettingsDialog(QDialog):
 
         engine.set_config('jellyfin_host',         self.jellyfin_host.text())
         engine.set_config('jellyfin_port',         self.jellyfin_port.text())
+        engine.set_config('jellyfin_ssl',        self.jellyfin_ssl.isChecked())
         engine.set_config('jellyfin_user',         self.jellyfin_user.text())
         engine.set_config('jellyfin_api_key',       self.jellyfin_api_key.text())
 
@@ -738,6 +742,7 @@ class SettingsDialog(QDialog):
         self.jellyfin_host.setEnabled(state)
         self.jellyfin_port.setEnabled(state)
         self.jellyfin_user.setEnabled(state)
+        self.jellyfin_ssl.setEnabled(state)
         self.jellyfin_api_key.setEnabled(state)
 
     def tracker_type_change(self, checked):

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -601,6 +601,7 @@ config_defaults = {
     'plex_ssl': False,
     'jellyfin_host': "localhost",
     'jellyfin_port': "8096",
+    'jellyfin_ssl': False,
     'jellyfin_api_key': '',
     'jellyfin_user': '',
     'kodi_host': "localhost",


### PR DESCRIPTION
I recently found an issue I found with the jellyfin tracker, presumably introduced in #571,  where requests would fail when the Jellyfin host configuration field would be set to an address without a protocol (e.g. `localhost` instead of `http://localhost`).

This PR fixes this issue by implementing the tracker with a similar implementation as the Plex tracker by adding a separate configuration flag on whether to use SSL and using that for requests as well.

This does mean that users need to input their Jellyfin host to an address without a protocol but I feel that this is pretty intuitive as the Jellyfin port is set in a separate field, but if possible I could add a commit to sanitize the host input before setting it. Let me know what you think on this.

I've tested the code as far as I could, and it seems to work, but only run Jellyfin locally and without SSL. The UI code might also need some review as it's been a while since I contributed to the project and UI is not my forte.

Cheers.