### PR TITLE
Silence a few debug prints

### DIFF
--- a/trackma/data.py
+++ b/trackma/data.py
@@ -433,8 +433,6 @@ class Data:
             self._save_cache()
             self._save_queue()
             self._emit_signal('sync_complete', items_processed)
-        else:
-            self.msg.debug('No items in queue.')
 
         self.meta['lastsend'] = time.time()
 

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -191,12 +191,12 @@ class Engine:
         if isinstance(filter_num, type(None)):
             source_list = self.get_list()
         elif isinstance(filter_num, list):
+            status_list = [s for s in filter_num if s is not self.mediainfo['statuses_finish']]
+            status_list_display = [self.mediainfo['statuses_dict'][s] for s in status_list]
+            self.msg.debug(f"Scanning for {', '.join(status_list_display)}")
             source_list = []
-            for status in filter_num:
-                if status is not self.mediainfo['statuses_finish']:
-                    self.msg.debug("Scanning for "
-                                   "{}".format(self.mediainfo['statuses_dict'][status]))
-                    source_list = source_list + self.filter_list(status)
+            for status in status_list:
+                source_list.extend(self.filter_list(status))
         else:
             source_list = self.filter_list(filter_num)
 

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -816,7 +816,7 @@ class Engine:
                 (library, library_cache) = self._add_show_to_library(
                     library, library_cache, rescan, fullpath, filename, tracker_list, guess_show)
 
-            self.msg.debug("Time: %s" % (time.time() - t))
+            self.msg.debug(f"Time: {time.time() - t:.3}s")
             self.data_handler.library_save(library)
             self.data_handler.library_cache_save(library_cache)
         return library


### PR DESCRIPTION
I always run the trackma CLI in debug mode to get more insights into what is going on (when things go wrong) and these lines could either be condensed or never provided any useful data for analysis.