### PR TITLE
Update Shikimori domain from shikimori.one to shikimori.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Currently supported websites
 - [Anilist](https://anilist.co/) (Anime, Manga)
 - [Kitsu](https://kitsu.app/) (Anime, Manga, Drama)
 - [MyAnimeList](https://myanimelist.net/) (Anime, Manga)
-- [Shikimori](https://shikimori.one/) (Anime, Manga)
+- [Shikimori](https://shikimori.io/) (Anime, Manga)
 - [VNDB](https://vndb.org/) (VNs)
 
 Screenshots

--- a/trackma/lib/libshikimori.py
+++ b/trackma/lib/libshikimori.py
@@ -29,7 +29,7 @@ class libshikimori(lib):
     """
     API class to communicate with Shikimori
 
-    Website: https://shikimori.one
+    Website: https://shikimori.io
 
     messenger: Messenger object to send useful messages to
     """
@@ -90,9 +90,9 @@ class libshikimori(lib):
     # Supported signals for the data handler
     signals = {'show_info_changed': None, }
 
-    url = "https://shikimori.one"
-    auth_url = "https://shikimori.one/oauth/token"
-    api_url = "https://shikimori.one/api"
+    url = "https://shikimori.io"
+    auth_url = "https://shikimori.io/oauth/token"
+    api_url = "https://shikimori.io/api"
 
     client_id = "Jfu9MKkUKPG4fOC95A6uwUVLHy3pwMo3jJB7YLSp7Ro"
     client_secret = "y7YmQx8n1l7eBRugUSiB7NfNJxaNBMvwppfxJLormXU"

--- a/trackma/utils.py
+++ b/trackma/utils.py
@@ -167,7 +167,7 @@ available_libs = {
     'mal':       ('MyAnimeList',  DATADIR + '/mal.jpg',     Login.OAUTH_PKCE,
                   "https://myanimelist.net/v1/oauth2/authorize?response_type=code&client_id=32c510ab2f47a1048a8dd24de266dc0c&code_challenge=%s"),
     'shikimori': ('Shikimori',    DATADIR + '/shikimori.jpg',   Login.OAUTH,
-                  "https://shikimori.one/oauth/authorize?client_id=Jfu9MKkUKPG4fOC95A6uwUVLHy3pwMo3jJB7YLSp7Ro&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&scope=user_rates"),
+                  "https://shikimori.io/oauth/authorize?client_id=Jfu9MKkUKPG4fOC95A6uwUVLHy3pwMo3jJB7YLSp7Ro&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&scope=user_rates"),
     'vndb':      ('VNDB',         DATADIR + '/vndb.jpg',        Login.PASSWD),
 }
 


### PR DESCRIPTION
## Summary

Shikimori has migrated to `shikimori.io` as the canonical domain. The old domain (`shikimori.one`) currently redirects, but API/OAuth URLs and docs should point to the new one.

- Update `url`, `auth_url`, `api_url` in `libshikimori.py`
- Update OAuth authorize URL in `utils.py`
- Update link in `README.md`

Fixes #835