### PR TITLE
Fix exception handling on anitopy episode number parsing

### DIFF
--- a/trackma/parser/anitopy.py
+++ b/trackma/parser/anitopy.py
@@ -58,10 +58,14 @@ class AnitopyWrapper():
         if self.episode_number is None:
             return 1
 
-        if type(self.episode_number) is list:
-            return int(self.episode_number[-1])
-        else:
-            return int(self.episode_number)
+        try:
+            if type(self.episode_number) is list:
+                return int(Decimal(self.episode_number[-1]))
+            else:
+                return int(Decimal(self.episode_number))
+        except ArithmeticError:
+            self.msg.warn("Unable to parse episode number '{}' of: {}"
+                              .format(self.episode_number, self.original_file_name))
 
     def getEpisodeNumbers(self, force_numbers=False):
         # Returns the episode range as a tuple


### PR DESCRIPTION
This PR aims to close #843. I opted to use the same logic that is already being used in `getEpisodeNumbers`, which is using Decimal to parse the episode number, and then trying to convert that into an int, while also gracefully handling ArithmeticErrors. This fix is what I used for the "Expected Behavior" in the issue, so I can confirm that it works for at least my problematic example.