### PR TITLE
Fix episode detection for certain batch formats when "take subdirectory name into account" is enabled

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -868,7 +868,16 @@ class Engine:
             # If it fails, cache it as None.
             anime_info = self.parser_class(self.msg, filename)
             show_title = anime_info.getName()
-            (show_ep_start, show_ep_end) = anime_info.getEpisodeNumbers(True)
+            if self.config['library_full_path']:
+                ep_info = self.parser_class(self.msg, os.path.basename(filename))
+                (show_ep_start, show_ep_end) = ep_info.getEpisodeNumbers(False)
+                if show_ep_start is None:
+                    (show_ep_start, show_ep_end) = anime_info.getEpisodeNumbers(True)
+                else:
+                    show_ep_start = int(show_ep_start)
+                    show_ep_end = int(show_ep_end) if show_ep_end is not None else show_ep_start
+            else:
+                (show_ep_start, show_ep_end) = anime_info.getEpisodeNumbers(True)
             if show_title:
                 show = guess_show(show_title)
                 if show:


### PR DESCRIPTION
Fixes #848

When library_full_path is on, _add_show_to_library extracted both series name and episode number from a file's full path, where the directory's episode range could interfere: a library with multiple batch folders ("Series (01-12)[batch]/Series - 07.mkv" and "OtherSeries [batch]/05 - Episode Title.mkv") would require this option, which causes wrong episode detection as the parser picked up the range from the directory name instead of the episode number from the filename.

Fix this by splitting the two concerns: run the parser on the full path to get the show title (benefiting from subdirectory context), but run a second parse on the bare basename to extract the episode number. Only fall back to the full-path parse for the episode number if the basename yields nothing (for a batch like "Series[batch]/07/Episode.mkv".

Note: extracting the basename via os.path.basename is slightly awkward since fullpath is available in add_to_library which calls _add_show_to_library, but this avoids larger changes to the codebase.