### PR TITLE
parser: add some hardening for anitopy & misc cleanups

### DIFF
--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -1067,7 +1067,7 @@ class Engine:
         try:
             return str(path.relative_to(searchdir))
         except ValueError:
-            return path.basename
+            return path.name
 
     def _searchdir_exists(self, path):
         """Variation of dir_exists that warns the user if the path doesn't exist."""

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -482,7 +482,7 @@ class Engine:
         list of show dictionaries with all the matches.
         """
         showlist = self.data_handler.get()
-        return list(v for k, v in showlist.items() if re.search(regex, v['title'], re.I))
+        return list(v for v in showlist.values() if re.search(regex, v['title'], re.I))
 
     def regex_list_titles(self, pattern):
         # TODO : Temporal hack for the client autocomplete function
@@ -824,7 +824,6 @@ class Engine:
     def remove_from_library(self, path, filename):
         library = self.data_handler.library_get()
         library_cache = self.data_handler.library_cache_get()
-        tracker_list = self._get_tracker_list()
         fullpath = path+"/"+filename
         # Only remove if the filename matches library entry
         if filename in library_cache and library_cache[filename]:
@@ -991,11 +990,11 @@ class Engine:
         if not args:
             raise utils.EngineError('Player not set up, check your config.json')
 
-        args[0] = shutil.which(args[0])
-
-        if not args[0]:
+        full_command = shutil.which(args[0])
+        if not full_command:
             raise utils.EngineError('Player not found, check your config.json')
 
+        args[0] = full_command
         args.append(filename)
         return args
 
@@ -1040,7 +1039,7 @@ class Engine:
         If you need a list with all the shows, use :func:`get_list`.
         """
         showlist = self.data_handler.get()
-        return list(v for k, v in showlist.items() if v['my_status'] == status_num)
+        return list(v for v in showlist.values() if v['my_status'] == status_num)
 
     def list_download(self):
         """Asks the data handler to download the remote list."""

--- a/trackma/engine.py
+++ b/trackma/engine.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import annotations
 
 import datetime
 import os
@@ -25,12 +26,16 @@ import time
 from decimal import Decimal
 from functools import lru_cache, partial
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from trackma import data
 from trackma import messenger
 from trackma import utils
 from trackma.extras import redirections
 from trackma.parser import get_parser_class
+
+if TYPE_CHECKING:
+    from .tracker import TrackerBase
 
 
 class Engine:
@@ -50,11 +55,11 @@ class Engine:
     The **message_handler** is a reference to a messaging function for the engine
     to send to. Optional.
     """
-    data_handler = None
-    tracker = None
+    data_handler: data.Data
+    tracker: TrackerBase | None = None
     redirections = None
     config = {}
-    msg = None
+    msg: messenger.Messenger
     loaded = False
     playing = False
     hooks_available = []

--- a/trackma/tracker/mpris.py
+++ b/trackma/tracker/mpris.py
@@ -196,7 +196,7 @@ class MprisTracker(tracker.TrackerBase):
                 self.msg.exception("Error in dbus watchers; cleaning up", sys.exc_info())
                 for task in tasks:
                     task.cancel()
-                await asyncio.gather(*tasks)
+                await asyncio.gather(*tasks, return_exceptions=True)
 
     async def name_owner_watcher(self, router):
         # Select name change signals for the well-known mpris service name.
@@ -396,7 +396,8 @@ class MprisTracker(tracker.TrackerBase):
     async def _on_tick(self):
         if self.active_player:
             try:
-                self.view_offset = int(await self.active_player.get_position()) / 1000
+                position = await self.active_player.get_position()
+                self.view_offset = int(position) / 1000 if position is not None else None
             except TypeError:
                 self.view_offset = None
                 # The view_offset is not important, so we ignore errors.

--- a/trackma/tracker/tracker.py
+++ b/trackma/tracker/tracker.py
@@ -15,6 +15,7 @@
 #
 
 import os
+import sys
 import threading
 import time
 
@@ -103,8 +104,8 @@ class TrackerBase(object):
 
     def _emit_signal(self, signal, *args):
         try:
-            if self.signals[signal]:
-                self.signals[signal](*args)
+            if callback := self.signals[signal]:
+                callback(*args)
         except KeyError:
             raise Exception("Call to undefined signal.")
 
@@ -258,8 +259,12 @@ class TrackerBase(object):
                         break
 
             # Invoke the parser to extract show title and episode.
-            aie = self.parser_class(self.msg, filename)
-            (show_title, show_ep) = (aie.getName(), aie.getEpisode())
+            try:
+                aie = self.parser_class(self.msg, filename)
+                (show_title, show_ep) = (aie.getName(), aie.getEpisode())
+            except Exception:
+                self.msg.exception('Failed to parse filename', sys.exc_info())
+                return (utils.Tracker.UNRECOGNIZED, None)
             if not show_title:
                 # Format not recognized
                 return (utils.Tracker.UNRECOGNIZED, None)


### PR DESCRIPTION
~~The primary motivator here was fixing a couple exceptions with the anitopy parser I collected over the years. Since the code is already terrible (for my standards), I really didn't want to spend much time with it and let some LLM go ham instead.  The added tests help with verifying that the code works "as expected", where "as expected" is not necessarily the best solution because of issues with anitopy but should at least cover some regressions.~~

I included some other changes I did earlier since I don't think they are no-brainers and do not deserve their own merge request.

Does not fix 843 anymore.
Related: #844 