### PR TITLE
polling: fix lsof arguments

### DIFF
--- a/trackma/tracker/polling.py
+++ b/trackma/tracker/polling.py
@@ -26,21 +26,27 @@ class PollingTracker(tracker.TrackerBase):
     name = 'Tracker (polling)'
 
     def get_playing_file(self, watch_dirs, players):
+        cmd = [
+            'lsof',
+            '-a',  # cause selection options to be AND-combined
+            '-w',  # suppress warnings (the man-page is ambiguous here but it's -w)
+            '-F', 'n',  # output only the name
+            '-c', f'/{players}/',  # match process (extended regex)
+        ]
         for path in watch_dirs:
-            # TODO: We'll run lsof once for each directory for now.
-            try:
-                lsof = subprocess.Popen(
-                    ['lsof', '-w', '-n', '-c', ''.join(['/', players, '/']), '-Fn', path], stdout=subprocess.PIPE)
-            except OSError:
-                self.msg.warn("Couldn't execute lsof. Disabling tracker.")
-                self.disable()
-                return None
+            cmd.extend(['+D', path])  # or-combined, recursive path lookup
+        try:
+            lsof = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        except OSError:
+            self.msg.warn("Couldn't execute lsof. Disabling tracker.")
+            self.disable()
+            return None
 
-            output = lsof.communicate()[0].decode('utf-8')
+        output = lsof.communicate()[0].decode('utf-8')
 
-            for line in output.splitlines():
-                if line[0] == 'n' and utils.is_media(line):
-                    return os.path.basename(line[1:])
+        for line in output.splitlines():
+            if line[0] == 'n' and utils.is_media(line):
+                return os.path.basename(line[1:])
 
         return None
 

--- a/trackma/tracker/polling.py
+++ b/trackma/tracker/polling.py
@@ -36,13 +36,11 @@ class PollingTracker(tracker.TrackerBase):
         for path in watch_dirs:
             cmd.extend(['+D', path])  # or-combined, recursive path lookup
         try:
-            lsof = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+            output = subprocess.check_output(cmd, text=True)
         except OSError:
             self.msg.warn("Couldn't execute lsof. Disabling tracker.")
             self.disable()
             return None
-
-        output = lsof.communicate()[0].decode('utf-8')
 
         for line in output.splitlines():
             if line[0] == 'n' and utils.is_media(line):


### PR DESCRIPTION
Different selection filters are OR-combined by default, which means the command was matching for files in the provided path OR files opened by commands that match the pattern. The `-a` option is what causes the filter to be AND-combined.

Additionally, suppress warnings (`+w`) and repeat the `+D` option for all watch dirs (multiple filters for the same kind are OR-combined even with `-a`) to implement the TODO comment and use a single command.

Fixes #851