### PR TITLE
Refactor MPRIS state tracking and improve tracker logic

### DIFF
--- a/trackma/tracker/inotify.py
+++ b/trackma/tracker/inotify.py
@@ -73,7 +73,7 @@ class inotifyTracker(inotifyBase.inotifyBase):
                     # Default blocking duration is 1 second
                     # This will count down like inotifyx impl. did
                     self.update_show_if_needed(
-                        self.last_state, self.last_show_tuple)
+                        self.last_state, self.last_show_tuple, self.last_filename)
         finally:
             self.msg.info('Tracker has stopped.')
             # inotify resource is cleaned-up automatically

--- a/trackma/tracker/inotify.py
+++ b/trackma/tracker/inotify.py
@@ -72,8 +72,8 @@ class inotifyTracker(inotifyBase.inotifyBase):
                 elif self.last_state != utils.Tracker.NOVIDEO and not self.last_updated:
                     # Default blocking duration is 1 second
                     # This will count down like inotifyx impl. did
-                    self.update_show_if_needed(
-                        self.last_state, self.last_show_tuple, self.last_filename)
+                    if self.last_resolution:
+                        self.update_show_if_needed(self.last_resolution, self.last_filename)
         finally:
             self.msg.info('Tracker has stopped.')
             # inotify resource is cleaned-up automatically

--- a/trackma/tracker/inotifyBase.py
+++ b/trackma/tracker/inotifyBase.py
@@ -117,12 +117,10 @@ class inotifyBase(tracker.TrackerBase):
             self._emit_signal('detected', path, name)
             self.open_file = (pathname, pid, fd)
 
-            if self.config['library_full_path']:
-                (state, show_tuple) = self._get_playing_show(pathname)
-            else:
-                (state, show_tuple) = self._get_playing_show(name)
+            filename = pathname if self.config['library_full_path'] else name
+            (state, show_tuple) = self.resolve_playing_show(filename)
             self.msg.debug("Got status: {} {}".format(state, show_tuple))
-            self.update_show_if_needed(state, show_tuple)
+            self.update_show_if_needed(state, show_tuple, filename)
         else:
             self.msg.debug("Not played by player, ignoring.")
 
@@ -143,5 +141,5 @@ class inotifyBase(tracker.TrackerBase):
         self._emit_signal('detected', path, name)
         self.open_file = (None, None, None)
 
-        (state, show_tuple) = self._get_playing_show(None)
-        self.update_show_if_needed(state, show_tuple)
+        (state, show_tuple) = self.resolve_playing_show(None)
+        self.update_show_if_needed(state, show_tuple, None)

--- a/trackma/tracker/inotifyBase.py
+++ b/trackma/tracker/inotifyBase.py
@@ -19,10 +19,10 @@ import re
 import time
 
 from trackma import utils
-from trackma.tracker import tracker
+from .tracker import TrackerBase, TrackerResolution
 
 
-class inotifyBase(tracker.TrackerBase):
+class inotifyBase(TrackerBase):
     open_file = (None, None, None)
 
     def __init__(self, messenger, tracker_list, config, watch_dirs, redirections=None):
@@ -118,7 +118,8 @@ class inotifyBase(tracker.TrackerBase):
             self.open_file = (pathname, pid, fd)
 
             filename = pathname if self.config['library_full_path'] else name
-            (state, show_tuple) = self.resolve_playing_show(filename)
+            resolution: TrackerResolution = self.resolve_playing_show(filename)
+            state, show_tuple = resolution
             self.msg.debug("Got status: {} {}".format(state, show_tuple))
             self.update_show_if_needed(state, show_tuple, filename)
         else:
@@ -141,5 +142,6 @@ class inotifyBase(tracker.TrackerBase):
         self._emit_signal('detected', path, name)
         self.open_file = (None, None, None)
 
-        (state, show_tuple) = self.resolve_playing_show(None)
+        resolution: TrackerResolution = self.resolve_playing_show(None)
+        state, show_tuple = resolution
         self.update_show_if_needed(state, show_tuple, None)

--- a/trackma/tracker/inotifyBase.py
+++ b/trackma/tracker/inotifyBase.py
@@ -19,7 +19,7 @@ import re
 import time
 
 from trackma import utils
-from .tracker import TrackerBase, TrackerResolution
+from .tracker import TrackerBase
 
 
 class inotifyBase(TrackerBase):
@@ -118,10 +118,9 @@ class inotifyBase(TrackerBase):
             self.open_file = (pathname, pid, fd)
 
             filename = pathname if self.config['library_full_path'] else name
-            resolution: TrackerResolution = self.resolve_playing_show(filename)
-            state, show_tuple = resolution
-            self.msg.debug("Got status: {} {}".format(state, show_tuple))
-            self.update_show_if_needed(state, show_tuple, filename)
+            resolution = self.resolve_playing_show(filename)
+            self.msg.debug("Got status: {}".format(resolution))
+            self.update_show_if_needed(resolution, filename)
         else:
             self.msg.debug("Not played by player, ignoring.")
 
@@ -142,6 +141,5 @@ class inotifyBase(TrackerBase):
         self._emit_signal('detected', path, name)
         self.open_file = (None, None, None)
 
-        resolution: TrackerResolution = self.resolve_playing_show(None)
-        state, show_tuple = resolution
-        self.update_show_if_needed(state, show_tuple, None)
+        resolution = self.resolve_playing_show(None)
+        self.update_show_if_needed(resolution, None)

--- a/trackma/tracker/jellyfin.py
+++ b/trackma/tracker/jellyfin.py
@@ -20,7 +20,7 @@ import time
 import urllib.request
 import json
 
-from trackma.tracker import tracker
+from .tracker import TrackerBase, TrackerResolution
 
 NOT_RUNNING = 0
 ACTIVE = 1
@@ -30,7 +30,7 @@ PAUSED = 4
 IDLE = 5
 
 
-class JellyfinTracker(tracker.TrackerBase):
+class JellyfinTracker(TrackerBase):
     name = 'Tracker (Jellyfin)'
 
     def __init__(self, messenger, tracker_list, config, watch_dirs, redirections=None):
@@ -57,7 +57,8 @@ class JellyfinTracker(tracker.TrackerBase):
                     self.wait_s = config['tracker_update_wait_s']
 
                 try:
-                    (state, show_tuple) = self.resolve_playing_show(session_info['file_name'])
+                    resolution: TrackerResolution = self.resolve_playing_show(session_info['file_name'])
+                    state, show_tuple = resolution
 
                     self.view_offset = int(session_info['view_offset'])
 

--- a/trackma/tracker/jellyfin.py
+++ b/trackma/tracker/jellyfin.py
@@ -15,12 +15,12 @@
 
 # TODO: Add gui stuff for this
 
+import json
 import os
 import time
 import urllib.request
-import json
 
-from .tracker import TrackerBase, TrackerResolution
+from .tracker import TrackerBase
 
 NOT_RUNNING = 0
 ACTIVE = 1
@@ -57,12 +57,11 @@ class JellyfinTracker(TrackerBase):
                     self.wait_s = config['tracker_update_wait_s']
 
                 try:
-                    resolution: TrackerResolution = self.resolve_playing_show(session_info['file_name'])
-                    state, show_tuple = resolution
+                    resolution = self.resolve_playing_show(session_info['file_name'])
 
                     self.view_offset = int(session_info['view_offset'])
 
-                    self.update_show_if_needed(state, show_tuple, session_info['file_name'])
+                    self.update_show_if_needed(resolution, session_info['file_name'])
 
                     if session_info['state'] == PAUSED:
                         self.pause_timer()
@@ -71,7 +70,7 @@ class JellyfinTracker(TrackerBase):
 
                 except (IndexError, TypeError):
                     if self.status_log[-1] == IDLE:
-                        self.update_show_if_needed(0, None, None)
+                        self.update_show_if_needed(self.resolve_playing_show(None), None)
                     else:
                         pass
 

--- a/trackma/tracker/jellyfin.py
+++ b/trackma/tracker/jellyfin.py
@@ -57,11 +57,11 @@ class JellyfinTracker(tracker.TrackerBase):
                     self.wait_s = config['tracker_update_wait_s']
 
                 try:
-                    (state, show_tuple) = self._get_playing_show(session_info['file_name'])
+                    (state, show_tuple) = self.resolve_playing_show(session_info['file_name'])
 
                     self.view_offset = int(session_info['view_offset'])
 
-                    self.update_show_if_needed(state, show_tuple)
+                    self.update_show_if_needed(state, show_tuple, session_info['file_name'])
 
                     if session_info['state'] == PAUSED:
                         self.pause_timer()
@@ -70,8 +70,7 @@ class JellyfinTracker(tracker.TrackerBase):
 
                 except (IndexError, TypeError):
                     if self.status_log[-1] == IDLE:
-                        self.last_filename = None
-                        self.update_show_if_needed(0, None)
+                        self.update_show_if_needed(0, None, None)
                     else:
                         pass
 

--- a/trackma/tracker/kodi.py
+++ b/trackma/tracker/kodi.py
@@ -19,6 +19,7 @@ import json
 import time
 import urllib.error
 import urllib.request
+from collections import deque
 
 from .tracker import TrackerBase
 
@@ -39,7 +40,7 @@ class KodiTracker(TrackerBase):
 
         self.host_port = "{}:{}".format(
             self.config['kodi_host'], self.config['kodi_port'])
-        self.status_log: list[int | None] = [None, None]
+        self.status_log: deque[int | None] = deque((None, None), maxlen=2)
         self.headers = {'content-type': 'application/json'}
         super().__init__(messenger, tracker_list, config, watch_dirs, redirections)
 
@@ -56,13 +57,12 @@ class KodiTracker(TrackerBase):
             else:
                 return IDLE
         except urllib.error.URLError as e:
-            if hasattr(e, 'code'):
-                if e.code == 401:
-                    return AUTH_REQUIRED
-                else:
-                    return NOT_RUNNING
-            else:
+            code = getattr(e, 'code', None)
+            if code is None:
                 return NOT_RUNNING
+            elif code == 401:
+                return AUTH_REQUIRED
+            return NOT_RUNNING
 
     def _playing_file(self):
         # returns the filename of the currently playing file
@@ -159,8 +159,6 @@ class KodiTracker(TrackerBase):
                 self.msg.warn("Authentication needed by Kodi, login in the settings and restart trackma.")
             elif self.status_log[-1] == NOT_RUNNING:
                 self.msg.warn("Kodi HTTP Server is not running.")
-
-            del self.status_log[0]
 
             # Wait for the interval before running check again
             time.sleep(config['tracker_interval'])

--- a/trackma/tracker/kodi.py
+++ b/trackma/tracker/kodi.py
@@ -144,9 +144,9 @@ class KodiTracker(tracker.TrackerBase):
                     self.wait_s = self._timer_from_file()
 
                 player = self._playing_file()
-                (state, show_tuple) = self._get_playing_show(player[0])
+                (state, show_tuple) = self.resolve_playing_show(player[0])
 
-                self.update_show_if_needed(state, show_tuple)
+                self.update_show_if_needed(state, show_tuple, player[0])
 
                 if player[1] == PAUSED:
                     self.pause_timer()

--- a/trackma/tracker/kodi.py
+++ b/trackma/tracker/kodi.py
@@ -20,7 +20,7 @@ import time
 import urllib.error
 import urllib.request
 
-from trackma.tracker import tracker
+from .tracker import TrackerBase, TrackerResolution
 
 NOT_RUNNING = 0
 IDLE = 1
@@ -31,7 +31,7 @@ PLAYING = 4
 PAUSED = 5
 
 
-class KodiTracker(tracker.TrackerBase):
+class KodiTracker(TrackerBase):
     name = 'Tracker (Kodi)'
 
     def __init__(self, messenger, tracker_list, config, watch_dirs, redirections=None):
@@ -39,7 +39,7 @@ class KodiTracker(tracker.TrackerBase):
 
         self.host_port = "{}:{}".format(
             self.config['kodi_host'], self.config['kodi_port'])
-        self.status_log = [None, None]
+        self.status_log: list[int | None] = [None, None]
         self.headers = {'content-type': 'application/json'}
         super().__init__(messenger, tracker_list, config, watch_dirs, redirections)
 
@@ -144,7 +144,8 @@ class KodiTracker(tracker.TrackerBase):
                     self.wait_s = self._timer_from_file()
 
                 player = self._playing_file()
-                (state, show_tuple) = self.resolve_playing_show(player[0])
+                resolution: TrackerResolution = self.resolve_playing_show(player[0])
+                state, show_tuple = resolution
 
                 self.update_show_if_needed(state, show_tuple, player[0])
 

--- a/trackma/tracker/kodi.py
+++ b/trackma/tracker/kodi.py
@@ -20,7 +20,7 @@ import time
 import urllib.error
 import urllib.request
 
-from .tracker import TrackerBase, TrackerResolution
+from .tracker import TrackerBase
 
 NOT_RUNNING = 0
 IDLE = 1
@@ -144,10 +144,11 @@ class KodiTracker(TrackerBase):
                     self.wait_s = self._timer_from_file()
 
                 player = self._playing_file()
-                resolution: TrackerResolution = self.resolve_playing_show(player[0])
-                state, show_tuple = resolution
+                if not player:
+                    continue
 
-                self.update_show_if_needed(state, show_tuple, player[0])
+                resolution = self.resolve_playing_show(player[0])
+                self.update_show_if_needed(resolution, player[0])
 
                 if player[1] == PAUSED:
                     self.pause_timer()

--- a/trackma/tracker/mpris.py
+++ b/trackma/tracker/mpris.py
@@ -23,6 +23,7 @@ import threading
 import time
 import urllib.parse
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -37,8 +38,6 @@ from .tracker import (
     OnStateCallback,
     OnTickCallback,
     TrackerBase,
-    ResolvePlayingShowCallback,
-    ShowTuple,
     TrackerResolution,
     TrackerState,
 )
@@ -142,7 +141,7 @@ class MprisDbusWatcher:
         self,
         config: dict[str, Any],
         msg,
-        resolve_playing_show: ResolvePlayingShowCallback,
+        resolve_playing_show: Callable[[str | None], TrackerResolution],
         on_state: OnStateCallback,
         on_playback: OnPlaybackCallback,
         on_tick: OnTickCallback,
@@ -150,7 +149,7 @@ class MprisDbusWatcher:
         # Note: all these should be considered private.
         self.config = config
         self.msg = msg
-        self.resolve_playing_show: ResolvePlayingShowCallback = resolve_playing_show
+        self.resolve_playing_show: Callable[[str | None], TrackerResolution] = resolve_playing_show
         self.on_state: OnStateCallback = on_state
         self.on_playback: OnPlaybackCallback = on_playback
         self.on_tick: OnTickCallback = on_tick
@@ -162,7 +161,7 @@ class MprisDbusWatcher:
         self.players: dict[str, Player] = {}
         self.active_player: Player | None = None
         self.active_filename: str | None = None
-        self.active_resolution: TrackerResolution = (utils.Tracker.NOVIDEO, None)
+        self.active_resolution: TrackerResolution = TrackerResolution.NO_VIDEO()
         self.timing = False
 
     async def run(self):
@@ -331,15 +330,15 @@ class MprisDbusWatcher:
             self._activate_player(player)
 
     def _activate_player(self, player: Player) -> bool:
-        state, show_tuple = self._resolve_player(player)
-        if state != utils.Tracker.PLAYING:
+        resolution = self._resolve_player(player)
+        if resolution.state != utils.Tracker.PLAYING:
             return False
 
         if player != self.active_player:
             self.msg.debug(f"Setting active player: {player.wellknown_name}")
             self.active_player = player
 
-        self._commit_player(player, state, show_tuple)
+        self._commit_player(player, resolution)
         return True
 
     def _resolve_player(self, player: Player) -> TrackerResolution:
@@ -354,14 +353,12 @@ class MprisDbusWatcher:
     def _commit_player(
         self,
         player: Player,
-        state: TrackerState | None = None,
-        show_tuple: ShowTuple | None = None,
+        resolution: TrackerResolution | None = None,
     ) -> None:
-        if state is None or show_tuple is None:
-            state, show_tuple = self._resolve_player(player)
+        resolution = resolution or self._resolve_player(player)
 
-        self.msg.debug(f"New tracker status: {state} (previously: {self.active_resolution[0]})")
-        self.on_state(state, show_tuple, player.filename)
+        self.msg.debug(f"New tracker status: {resolution.state} (previously: {self.active_resolution[0]})")
+        self.on_state(resolution, player.filename)
         self._set_timer_state(player.playback_status)
 
     def clear_state(self) -> None:
@@ -369,8 +366,8 @@ class MprisDbusWatcher:
             self.msg.debug(f"Clearing active player: {self.active_player.wellknown_name}")
         self.active_player = None
         self.active_filename = None
-        self.active_resolution = (utils.Tracker.NOVIDEO, None)
-        self.on_state(utils.Tracker.NOVIDEO, None, None)
+        self.active_resolution = TrackerResolution.NO_VIDEO()
+        self.on_state(TrackerResolution.NO_VIDEO(), None)
         self._set_timer_state(PlaybackStatus.STOPPED)
 
     def _set_timer_state(self, playback_status: str | None) -> None:
@@ -440,11 +437,10 @@ class MprisTracker(TrackerBase):
 
     def _on_tracker_state(
         self,
-        state: TrackerState,
-        show_tuple: ShowTuple | None,
+        resolution: TrackerResolution,
         filename: str | None,
     ) -> None:
-        self.update_show_if_needed(state, show_tuple, filename)
+        self.update_show_if_needed(resolution, filename)
 
     def _on_tracker_playback(self, playing: bool) -> None:
         if playing:

--- a/trackma/tracker/mpris.py
+++ b/trackma/tracker/mpris.py
@@ -15,21 +15,22 @@
 #
 from __future__ import annotations
 
-from enum import Enum
+import asyncio
 import os
 import re
 import sys
 import threading
 import time
 import urllib.parse
-import asyncio
-from typing import Any
-from dataclasses import dataclass
 from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
 
-from jeepney import HeaderFields, Properties, DBusAddress
-from jeepney.io.asyncio import open_dbus_router, DBusRouter, Proxy
-from jeepney.bus_messages import message_bus, MatchRule
+from jeepney import DBusAddress, HeaderFields, Properties
+from jeepney.bus_messages import MatchRule, message_bus
+from jeepney.io.asyncio import DBusRouter, Proxy, open_dbus_router
 
 from trackma import utils
 from trackma.tracker import tracker
@@ -44,6 +45,16 @@ PATH_MPRIS = '/org/mpris/MediaPlayer2'
 IFACE_PROPERTIES = 'org.freedesktop.DBus.Properties'
 IFACE_MPRIS = 'org.mpris.MediaPlayer2'
 IFACE_MPRIS_PLAYER = IFACE_MPRIS + '.Player'
+
+if TYPE_CHECKING:
+    from typing import Any, TypeAlias
+    ShowTuple: TypeAlias = tuple[dict[str, Any], int]
+    TrackerState: TypeAlias = utils.Tracker
+    TrackerResolution: TypeAlias = tuple[TrackerState, ShowTuple | None]
+    ResolvePlayingShowCallback: TypeAlias = Callable[[str | None], TrackerResolution]
+    OnStateCallback: TypeAlias = Callable[[TrackerState, ShowTuple | None, str | None], None]
+    OnPlaybackCallback: TypeAlias = Callable[[bool], None]
+    OnTickCallback: TypeAlias = Callable[[float | None], None]
 
 
 class PlaybackStatus(str, Enum):
@@ -99,8 +110,7 @@ class Player:
             if self.config['library_full_path'] and unquoted_url.startswith('file://'):
                 return unquoted_url.removeprefix('file://')
             return os.path.basename(unquoted_url)
-        else:
-            return self.title
+        return self.title
 
     async def update_filename(self):
         msg = self._player_properties.get('Metadata')
@@ -129,49 +139,36 @@ class Player:
         return Properties(address)
 
 
-class MprisTracker(tracker.TrackerBase):
+class MprisDbusWatcher:
 
-    name = 'Tracker (MPRIS)'
-
-    def __init__(self, *args, **kwargs):
-        # `TrackerBase.__init__` spawns a new thread for `observe`
-        # where we wait for this event.
-        self.initialized = threading.Event()
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        config: dict[str, Any],
+        msg,
+        resolve_playing_show: ResolvePlayingShowCallback,
+        on_state: OnStateCallback,
+        on_playback: OnPlaybackCallback,
+        on_tick: OnTickCallback,
+    ):
+        # Note: all these should be considered private.
+        self.config = config
+        self.msg = msg
+        self.resolve_playing_show: ResolvePlayingShowCallback = resolve_playing_show
+        self.on_state: OnStateCallback = on_state
+        self.on_playback: OnPlaybackCallback = on_playback
+        self.on_tick: OnTickCallback = on_tick
 
         self.re_players = re.compile(self.config['tracker_process'])
         # Map "OwnerName"s to Player instances
         # for monitoring when one appears or disappears
         # via the `NameOwnerChanged` signal.
-        self.players = {}
+        self.players: dict[str, Player] = {}
+        self.active_player: Player | None = None
+        self.active_filename: str | None = None
+        self.active_resolution: TrackerResolution = (utils.Tracker.NOVIDEO, None)
         self.timing = False
-        self.active_player = None
-        self.initialized.set()
 
-    def update_list(self, *args, **kwargs):
-        super().update_list(*args, **kwargs)
-        if self.last_state != utils.Tracker.PLAYING:
-            # Re-check if we have any player with a valid show running after a list update
-            self.last_filename = None
-            self.find_playing_player()
-
-    def observe(self, config, watch_dirs):
-        self.msg.info("Using MPRIS.")
-        self.initialized.wait()
-
-        # Permit 5 starts within 60 seconds,
-        # waiting for 5s between each retry.
-        # If it fails more frequently,
-        # we consider the tracker to be broken and let it die.
-        start_times = deque(maxlen=5)
-        while len(start_times) < 5 or start_times[0] + 60 < time.time():
-            start_times.append(time.time())
-            asyncio.run(self.observe_async())
-            time.sleep(5)
-
-        self.msg.warn("Reached restart limit for MPRIS tracker.")
-
-    async def observe_async(self):
+    async def run(self):
         async with open_dbus_router() as router:
             name_owner_watcher_task = asyncio.create_task(self.name_owner_watcher(router))
             properties_watcher_task = asyncio.create_task(self.properties_watcher(router))
@@ -188,7 +185,8 @@ class MprisTracker(tracker.TrackerBase):
             self.msg.debug(f"Ignoring players: {ignored_players}")
             for player in self.players.values():
                 self.msg.debug(f"Player connected: {player.wellknown_name}")
-            self.find_playing_player()
+
+            self.reselect()
 
             try:
                 await asyncio.gather(*tasks)
@@ -223,7 +221,7 @@ class MprisTracker(tracker.TrackerBase):
                 msg = await queue.get()
                 (wellknown_name, old_name, new_name) = msg.body
                 if old_name:
-                    self.on_bus_removed(wellknown_name, old_name)
+                    self.on_bus_removed(old_name)
                 if new_name:
                     await self.on_bus_added(router, wellknown_name, new_name)
 
@@ -237,14 +235,14 @@ class MprisTracker(tracker.TrackerBase):
         self.players[unique_name] = player
         self._handle_player_update(player)
 
-    def on_bus_removed(self, wellknown_name, unique_name):
+    def on_bus_removed(self, unique_name):
         player = self.players.pop(unique_name, None)
         if not player:
             return
         self.msg.debug(f"Player disconnected: {player.wellknown_name}")
         if player == self.active_player:
-            self._handle_player_stopped()
-            self.active_player = None
+            self.clear_state()
+            self.reselect()
 
     async def properties_watcher(self, router):
         # Select PropertiesChanged signals for the mpris-player subinterface
@@ -283,26 +281,34 @@ class MprisTracker(tracker.TrackerBase):
         except TypeError as e:
             self.msg.warn(f"Failed to read properties for {sender}: {e}")
 
-    def valid_player(self, wellknown_name):
+    def valid_player(self, wellknown_name: str) -> re.Match[str] | None:
         return self.re_players.search(wellknown_name)
 
-    def find_playing_player(self) -> bool:
+    def reselect(self):
+        # Prioritize active player if it is still playing.
+        if (
+            self.active_player
+            and self.active_player.playback_status == PlaybackStatus.PLAYING
+            and self._activate_player(self.active_player)
+        ):
+            return
+
         # Go through all connected players in random order
         # (or not since dicts are ordered now).
-        return any(
-            self._update_active_player(player, probing=True)
-            for player in self.players.values()
-            if player.playback_status == PlaybackStatus.PLAYING
-        )
+        for player in self.players.values():
+            if player.playback_status == PlaybackStatus.PLAYING and self._activate_player(player):
+                return
 
-    def on_playback_status_change(self, sender, playback_status):
+        self.clear_state()
+
+    def on_playback_status_change(self, sender: str, playback_status: str) -> None:
         player = self.players.get(sender)
         if not player:
             return
         player.playback_status = playback_status
         self._handle_player_update(player)
 
-    def on_filename_change(self, sender, title, url):
+    def on_filename_change(self, sender: str, title: str | None, url: str | None) -> None:
         player = self.players.get(sender)
         if not player:
             return
@@ -310,82 +316,76 @@ class MprisTracker(tracker.TrackerBase):
         player.url = url
         self._handle_player_update(player)
 
-    def _handle_player_update(self, player):
+    def _handle_player_update(self, player: Player) -> None:
         if player == self.active_player:
             if player.playback_status == PlaybackStatus.STOPPED:
-                self._handle_player_stopped()
-            else:
-                self._update_active_player(player)
+                self.clear_state()
+                self.reselect()
+                return
 
-        elif self.active_player and self.active_player.playback_status == PlaybackStatus.PLAYING:
+            self._commit_player(player)
+            return
+
+        if self.active_player and self.active_player.playback_status == PlaybackStatus.PLAYING:
             self.msg.debug("Still playing on active player; ignoring update")
             return
 
-        elif player.playback_status == PlaybackStatus.PLAYING:
-            self._update_active_player(player)
+        if player.playback_status == PlaybackStatus.PLAYING:
+            self._activate_player(player)
 
-    def _update_active_player(self, player: Player, probing=False) -> bool:
-        is_new_player = player != self.active_player
-
-        (state, show_tuple) = (None, None)
-        previous_last_filename = self.last_filename
-        new_show = False
-        if player.filename != self.last_filename:
-            (state, show_tuple) = self._get_playing_show(player.filename)
-            if state in [utils.Tracker.UNRECOGNIZED, utils.Tracker.NOT_FOUND]:
-                self.msg.debug("Video not recognized")
-            elif state == utils.Tracker.NOVIDEO:
-                self.msg.debug("No video loaded")
-            else:
-                new_show = True
-
-        if is_new_player and not new_show:
-            if probing:
-                # Ignore this 'new' player & restore `last_filename`
-                # since we're just looking for a new player candidate.
-                # (This is a hack but a proper fix needs larger refactoring
-                # involving the parent class.)
-                self.last_filename = previous_last_filename
+    def _activate_player(self, player: Player) -> bool:
+        state, show_tuple = self._resolve_player(player)
+        if state != utils.Tracker.PLAYING:
             return False
 
-        if is_new_player and new_show:
+        if player != self.active_player:
             self.msg.debug(f"Setting active player: {player.wellknown_name}")
             self.active_player = player
 
-        if state:
-            self.msg.debug(f"New tracker status: {state} (previously: {self.last_state})")
-            self.update_show_if_needed(state, show_tuple)
-
-        if player.playback_status == PlaybackStatus.PLAYING:
-            self._start_timer()
-        else:
-            self._stop_timer()
-
+        self._commit_player(player, state, show_tuple)
         return True
 
-    def _handle_player_stopped(self):
-        # Active player got closed!
+    def _resolve_player(self, player: Player) -> TrackerResolution:
+        filename = player.filename
+        if filename == self.active_filename:
+            return self.active_resolution
+        self.active_filename = filename
+
+        self.active_resolution = self.resolve_playing_show(filename)
+        return self.active_resolution
+
+    def _commit_player(
+        self,
+        player: Player,
+        state: TrackerState | None = None,
+        show_tuple: tuple[dict[str, Any], int] | None = None,
+    ) -> None:
+        if state is None or show_tuple is None:
+            state, show_tuple = self._resolve_player(player)
+
+        self.msg.debug(f"New tracker status: {state} (previously: {self.active_resolution[0]})")
+        self.on_state(state, show_tuple, player.filename)
+        self._set_timer_state(player.playback_status)
+
+    def clear_state(self) -> None:
         if self.active_player:
             self.msg.debug(f"Clearing active player: {self.active_player.wellknown_name}")
         self.active_player = None
-        self.view_offset = None
+        self.active_filename = None
+        self.active_resolution = (utils.Tracker.NOVIDEO, None)
+        self.on_state(utils.Tracker.NOVIDEO, None, None)
+        self._set_timer_state(PlaybackStatus.STOPPED)
 
-        if not self.find_playing_player():
-            (state, show_tuple) = self._get_playing_show(None)
-            self.update_show_if_needed(state, show_tuple)
-            self._stop_timer()
-
-    def _start_timer(self):
-        self.resume_timer()
-        if not self.timing:
+    def _set_timer_state(self, playback_status: str | None) -> None:
+        playing = playback_status == PlaybackStatus.PLAYING
+        if playing and not self.timing:
             self.timing = True
             self.msg.debug("MPRIS timer started.")
-
-    def _stop_timer(self):
-        self.pause_timer()
-        if self.timing:
+            self.on_playback(True)
+        elif not playing and self.timing:
             self.timing = False
             self.msg.debug("MPRIS timer paused.")
+            self.on_playback(False)
 
     async def _timer(self):
         while True:
@@ -393,17 +393,69 @@ class MprisTracker(tracker.TrackerBase):
                 await self._on_tick()
             await asyncio.sleep(1, True)
 
-    async def _on_tick(self):
+    async def _on_tick(self) -> None:
         if self.active_player:
             try:
-                self.view_offset = int(await self.active_player.get_position()) / 1000
+                position = await self.active_player.get_position()
+                view_offset = int(position) / 1000 if position is not None else None
             except TypeError:
-                self.view_offset = None
-                # The view_offset is not important, so we ignore errors.
-                pass
+                view_offset = None
+        else:
+            view_offset = None
 
+        self.on_tick(view_offset)
+
+
+class MprisTracker(tracker.TrackerBase):
+
+    name = 'Tracker (MPRIS)'
+
+    def __init__(self, *args, **kwargs):
+        self.initialized = threading.Event()
+        super().__init__(*args, **kwargs)
+
+        self.watcher = MprisDbusWatcher(
+            self.config,
+            self.msg,
+            self.resolve_playing_show,
+            self._on_tracker_state,
+            self._on_tracker_playback,
+            self._on_tracker_tick,
+        )
+        self.initialized.set()
+
+    def update_list(self, *args, **kwargs):
+        super().update_list(*args, **kwargs)
+        self.watcher.clear_state()
+        self.watcher.reselect()
+
+    def observe(self, _config, _watch_dirs):
+        self.msg.info("Using MPRIS.")
+        self.initialized.wait()
+
+        start_times = deque(maxlen=5)
+        while len(start_times) < 5 or start_times[0] + 60 < time.time():
+            start_times.append(time.time())
+            asyncio.run(self.watcher.run())
+            time.sleep(5)
+
+        self.msg.warn("Reached restart limit for MPRIS tracker.")
+
+    def _on_tracker_state(
+        self,
+        state: TrackerState,
+        show_tuple: tuple[dict[str, Any], int] | None,
+        filename: str | None,
+    ) -> None:
+        self.update_show_if_needed(state, show_tuple, filename)
+
+    def _on_tracker_playback(self, playing: bool) -> None:
+        if playing:
+            self.resume_timer()
+        else:
+            self.pause_timer()
+
+    def _on_tracker_tick(self, view_offset: float | None) -> None:
+        self.view_offset = view_offset
         if self.last_show_tuple:
             self.update_timer(self.last_state, self.last_show_tuple)
-
-        if self.last_updated:
-            self._stop_timer()

--- a/trackma/tracker/mpris.py
+++ b/trackma/tracker/mpris.py
@@ -23,17 +23,25 @@ import threading
 import time
 import urllib.parse
 from collections import deque
-from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import Any
 
 from jeepney import DBusAddress, HeaderFields, Properties
 from jeepney.bus_messages import MatchRule, message_bus
 from jeepney.io.asyncio import DBusRouter, Proxy, open_dbus_router
 
 from trackma import utils
-from trackma.tracker import tracker
+from .tracker import (
+    OnPlaybackCallback,
+    OnStateCallback,
+    OnTickCallback,
+    TrackerBase,
+    ResolvePlayingShowCallback,
+    ShowTuple,
+    TrackerResolution,
+    TrackerState,
+)
 
 __all__ = [
     'MprisTracker',
@@ -45,17 +53,6 @@ PATH_MPRIS = '/org/mpris/MediaPlayer2'
 IFACE_PROPERTIES = 'org.freedesktop.DBus.Properties'
 IFACE_MPRIS = 'org.mpris.MediaPlayer2'
 IFACE_MPRIS_PLAYER = IFACE_MPRIS + '.Player'
-
-if TYPE_CHECKING:
-    from typing import Any, TypeAlias
-    ShowTuple: TypeAlias = tuple[dict[str, Any], int]
-    TrackerState: TypeAlias = utils.Tracker
-    TrackerResolution: TypeAlias = tuple[TrackerState, ShowTuple | None]
-    ResolvePlayingShowCallback: TypeAlias = Callable[[str | None], TrackerResolution]
-    OnStateCallback: TypeAlias = Callable[[TrackerState, ShowTuple | None, str | None], None]
-    OnPlaybackCallback: TypeAlias = Callable[[bool], None]
-    OnTickCallback: TypeAlias = Callable[[float | None], None]
-
 
 class PlaybackStatus(str, Enum):
     PLAYING = 'Playing'
@@ -358,7 +355,7 @@ class MprisDbusWatcher:
         self,
         player: Player,
         state: TrackerState | None = None,
-        show_tuple: tuple[dict[str, Any], int] | None = None,
+        show_tuple: ShowTuple | None = None,
     ) -> None:
         if state is None or show_tuple is None:
             state, show_tuple = self._resolve_player(player)
@@ -406,7 +403,7 @@ class MprisDbusWatcher:
         self.on_tick(view_offset)
 
 
-class MprisTracker(tracker.TrackerBase):
+class MprisTracker(TrackerBase):
 
     name = 'Tracker (MPRIS)'
 
@@ -444,7 +441,7 @@ class MprisTracker(tracker.TrackerBase):
     def _on_tracker_state(
         self,
         state: TrackerState,
-        show_tuple: tuple[dict[str, Any], int] | None,
+        show_tuple: ShowTuple | None,
         filename: str | None,
     ) -> None:
         self.update_show_if_needed(state, show_tuple, filename)

--- a/trackma/tracker/mpris.py
+++ b/trackma/tracker/mpris.py
@@ -457,5 +457,4 @@ class MprisTracker(tracker.TrackerBase):
 
     def _on_tracker_tick(self, view_offset: float | None) -> None:
         self.view_offset = view_offset
-        if self.last_show_tuple:
-            self.update_timer(self.last_state, self.last_show_tuple)
+        self.update_timer()

--- a/trackma/tracker/mpris.py
+++ b/trackma/tracker/mpris.py
@@ -33,13 +33,13 @@ from jeepney.bus_messages import MatchRule, message_bus
 from jeepney.io.asyncio import DBusRouter, Proxy, open_dbus_router
 
 from trackma import utils
+
 from .tracker import (
     OnPlaybackCallback,
     OnStateCallback,
     OnTickCallback,
     TrackerBase,
     TrackerResolution,
-    TrackerState,
 )
 
 __all__ = [
@@ -52,6 +52,7 @@ PATH_MPRIS = '/org/mpris/MediaPlayer2'
 IFACE_PROPERTIES = 'org.freedesktop.DBus.Properties'
 IFACE_MPRIS = 'org.mpris.MediaPlayer2'
 IFACE_MPRIS_PLAYER = IFACE_MPRIS + '.Player'
+
 
 class PlaybackStatus(str, Enum):
     PLAYING = 'Playing'
@@ -317,49 +318,57 @@ class MprisDbusWatcher:
             if player.playback_status == PlaybackStatus.STOPPED:
                 self.clear_state()
                 self.reselect()
-                return
+            else:
+                resolution = self._resolve_player(player)
+                self._commit_resolution(resolution)
 
-            self._commit_player(player)
-            return
-
-        if self.active_player and self.active_player.playback_status == PlaybackStatus.PLAYING:
+        elif (
+            self.active_player
+            and self.active_player.playback_status == PlaybackStatus.PLAYING
+            and self.active_resolution.state == utils.Tracker.PLAYING
+        ):
             self.msg.debug("Still playing on active player; ignoring update")
-            return
 
-        if player.playback_status == PlaybackStatus.PLAYING:
+        elif player.playback_status == PlaybackStatus.PLAYING:
             self._activate_player(player)
 
     def _activate_player(self, player: Player) -> bool:
         resolution = self._resolve_player(player)
-        if resolution.state != utils.Tracker.PLAYING:
-            return False
 
         if player != self.active_player:
             self.msg.debug(f"Setting active player: {player.wellknown_name}")
             self.active_player = player
 
-        self._commit_player(player, resolution)
-        return True
+        self._commit_resolution(resolution)
+        return resolution.state == utils.Tracker.PLAYING
 
     def _resolve_player(self, player: Player) -> TrackerResolution:
         filename = player.filename
         if filename == self.active_filename:
             return self.active_resolution
-        self.active_filename = filename
 
-        self.active_resolution = self.resolve_playing_show(filename)
-        return self.active_resolution
+        return self.resolve_playing_show(filename)
 
-    def _commit_player(
+    def _commit_resolution(
         self,
-        player: Player,
-        resolution: TrackerResolution | None = None,
+        resolution: TrackerResolution,
     ) -> None:
-        resolution = resolution or self._resolve_player(player)
+        if not self.active_player:
+            return
+
+        playing = (
+            self.active_player.playback_status == PlaybackStatus.PLAYING
+            and resolution.state == utils.Tracker.PLAYING
+        )
+        self._set_timer_state(playing)
+
+        if resolution == self.active_resolution:
+            return
 
         self.msg.debug(f"New tracker status: {resolution.state} (previously: {self.active_resolution[0]})")
-        self.on_state(resolution, player.filename)
-        self._set_timer_state(player.playback_status)
+        self.active_resolution = resolution
+        self.active_filename = self.active_player.filename
+        self.on_state(resolution, self.active_player.filename)
 
     def clear_state(self) -> None:
         if self.active_player:
@@ -368,10 +377,9 @@ class MprisDbusWatcher:
         self.active_filename = None
         self.active_resolution = TrackerResolution.NO_VIDEO()
         self.on_state(TrackerResolution.NO_VIDEO(), None)
-        self._set_timer_state(PlaybackStatus.STOPPED)
+        self._set_timer_state(False)
 
-    def _set_timer_state(self, playback_status: str | None) -> None:
-        playing = playback_status == PlaybackStatus.PLAYING
+    def _set_timer_state(self, playing: bool) -> None:
         if playing and not self.timing:
             self.timing = True
             self.msg.debug("MPRIS timer started.")
@@ -411,10 +419,10 @@ class MprisTracker(TrackerBase):
         self.watcher = MprisDbusWatcher(
             self.config,
             self.msg,
-            self.resolve_playing_show,
-            self._on_tracker_state,
-            self._on_tracker_playback,
-            self._on_tracker_tick,
+            resolve_playing_show=self.resolve_playing_show,
+            on_state=self._on_tracker_state,
+            on_playback=self._on_tracker_playback,
+            on_tick=self._on_tracker_tick,
         )
         self.initialized.set()
 

--- a/trackma/tracker/plex.py
+++ b/trackma/tracker/plex.py
@@ -22,7 +22,7 @@ import urllib.request
 import xml.dom.minidom as xdmd
 
 import trackma.utils as utils
-from trackma.tracker import tracker
+from .tracker import TrackerBase, TrackerResolution
 
 NOT_RUNNING = 0
 ACTIVE = 1
@@ -32,7 +32,7 @@ PAUSED = 4
 IDLE = 5
 
 
-class PlexTracker(tracker.TrackerBase):
+class PlexTracker(TrackerBase):
     name = 'Tracker (Plex)'
 
     def __init__(self, messenger, tracker_list, config, watch_dirs, redirections=None):
@@ -108,7 +108,8 @@ class PlexTracker(tracker.TrackerBase):
                     xuser = self._get_sessions_info("User", "title")
 
                     player = self.playing_file()
-                    (state, show_tuple) = self.resolve_playing_show(player[0])
+                    resolution: TrackerResolution = self.resolve_playing_show(player[0])
+                    state, show_tuple = resolution
 
                     if self.token:
                         if self.config['plex_user'] == xuser:

--- a/trackma/tracker/plex.py
+++ b/trackma/tracker/plex.py
@@ -108,19 +108,19 @@ class PlexTracker(tracker.TrackerBase):
                     xuser = self._get_sessions_info("User", "title")
 
                     player = self.playing_file()
-                    (state, show_tuple) = self._get_playing_show(player[0])
+                    (state, show_tuple) = self.resolve_playing_show(player[0])
 
                     if self.token:
                         if self.config['plex_user'] == xuser:
                             self.view_offset = int(self._get_sessions_info("Video", "viewOffset"))
-                            self.update_show_if_needed(state, show_tuple)
+                            self.update_show_if_needed(state, show_tuple, player[0])
 
                             if player[1] == PAUSED:
                                 self.pause_timer()
                             elif player[1] == PLAYING:
                                 self.resume_timer()
                     else:
-                        self.update_show_if_needed(state, show_tuple)
+                        self.update_show_if_needed(state, show_tuple, player[0])
 
                         if player[1] == PAUSED:
                             self.pause_timer()
@@ -128,8 +128,7 @@ class PlexTracker(tracker.TrackerBase):
                             self.resume_timer()
                 except IndexError:
                     if self.status_log[-1] == IDLE:
-                        self.last_filename = None
-                        self.update_show_if_needed(0, None)
+                        self.update_show_if_needed(0, None, None)
                     else:
                         pass
             elif self.status_log[-1] == CLAIMED and self.status_log[-2] == CLAIMED:

--- a/trackma/tracker/plex.py
+++ b/trackma/tracker/plex.py
@@ -22,7 +22,7 @@ import urllib.request
 import xml.dom.minidom as xdmd
 
 import trackma.utils as utils
-from .tracker import TrackerBase, TrackerResolution
+from .tracker import TrackerBase
 
 NOT_RUNNING = 0
 ACTIVE = 1
@@ -108,20 +108,19 @@ class PlexTracker(TrackerBase):
                     xuser = self._get_sessions_info("User", "title")
 
                     player = self.playing_file()
-                    resolution: TrackerResolution = self.resolve_playing_show(player[0])
-                    state, show_tuple = resolution
+                    resolution = self.resolve_playing_show(player[0])
 
                     if self.token:
                         if self.config['plex_user'] == xuser:
                             self.view_offset = int(self._get_sessions_info("Video", "viewOffset"))
-                            self.update_show_if_needed(state, show_tuple, player[0])
+                            self.update_show_if_needed(resolution, player[0])
 
                             if player[1] == PAUSED:
                                 self.pause_timer()
                             elif player[1] == PLAYING:
                                 self.resume_timer()
                     else:
-                        self.update_show_if_needed(state, show_tuple, player[0])
+                        self.update_show_if_needed(resolution, player[0])
 
                         if player[1] == PAUSED:
                             self.pause_timer()
@@ -129,7 +128,7 @@ class PlexTracker(TrackerBase):
                             self.resume_timer()
                 except IndexError:
                     if self.status_log[-1] == IDLE:
-                        self.update_show_if_needed(0, None, None)
+                        self.update_show_if_needed(self.resolve_playing_show(None), None)
                     else:
                         pass
             elif self.status_log[-1] == CLAIMED and self.status_log[-2] == CLAIMED:

--- a/trackma/tracker/polling.py
+++ b/trackma/tracker/polling.py
@@ -19,7 +19,7 @@ import subprocess
 import time
 
 from trackma import utils
-from .tracker import TrackerBase, TrackerResolution
+from .tracker import TrackerBase
 
 
 class PollingTracker(TrackerBase):
@@ -50,9 +50,8 @@ class PollingTracker(TrackerBase):
             # This runs the tracker and update the playing show if necessary
             filename = self.get_playing_file(
                 watch_dirs, config['tracker_process'])
-            resolution: TrackerResolution = self.resolve_playing_show(filename)
-            state, show_tuple = resolution
-            self.update_show_if_needed(state, show_tuple, filename)
+            resolution = self.resolve_playing_show(filename)
+            self.update_show_if_needed(resolution, filename)
 
             # Wait for the interval before running check again
             time.sleep(config['tracker_interval'])

--- a/trackma/tracker/polling.py
+++ b/trackma/tracker/polling.py
@@ -19,10 +19,10 @@ import subprocess
 import time
 
 from trackma import utils
-from trackma.tracker import tracker
+from .tracker import TrackerBase, TrackerResolution
 
 
-class PollingTracker(tracker.TrackerBase):
+class PollingTracker(TrackerBase):
     name = 'Tracker (polling)'
 
     def get_playing_file(self, watch_dirs, players):
@@ -50,7 +50,8 @@ class PollingTracker(tracker.TrackerBase):
             # This runs the tracker and update the playing show if necessary
             filename = self.get_playing_file(
                 watch_dirs, config['tracker_process'])
-            (state, show_tuple) = self.resolve_playing_show(filename)
+            resolution: TrackerResolution = self.resolve_playing_show(filename)
+            state, show_tuple = resolution
             self.update_show_if_needed(state, show_tuple, filename)
 
             # Wait for the interval before running check again

--- a/trackma/tracker/polling.py
+++ b/trackma/tracker/polling.py
@@ -50,8 +50,8 @@ class PollingTracker(tracker.TrackerBase):
             # This runs the tracker and update the playing show if necessary
             filename = self.get_playing_file(
                 watch_dirs, config['tracker_process'])
-            (state, show_tuple) = self._get_playing_show(filename)
-            self.update_show_if_needed(state, show_tuple)
+            (state, show_tuple) = self.resolve_playing_show(filename)
+            self.update_show_if_needed(state, show_tuple, filename)
 
             # Wait for the interval before running check again
             time.sleep(config['tracker_interval'])

--- a/trackma/tracker/pyinotify.py
+++ b/trackma/tracker/pyinotify.py
@@ -97,9 +97,9 @@ class pyinotifyTracker(inotifyBase.inotifyBase):
                         timeout = 1000  # Check each second for counting
                 elif self.active:
                     self.msg.debug("Sending last state {} {}".format(
-                        self.last_state, self.last_show_tuple))
-                    self.update_show_if_needed(
-                        self.last_state, self.last_show_tuple, self.last_filename)
+                        self.last_state, self.last_resolution))
+                    if self.last_resolution:
+                        self.update_show_if_needed(self.last_resolution, self.last_filename)
         finally:
             notifier.stop()
             self.msg.info('Tracker has stopped.')

--- a/trackma/tracker/pyinotify.py
+++ b/trackma/tracker/pyinotify.py
@@ -99,7 +99,7 @@ class pyinotifyTracker(inotifyBase.inotifyBase):
                     self.msg.debug("Sending last state {} {}".format(
                         self.last_state, self.last_show_tuple))
                     self.update_show_if_needed(
-                        self.last_state, self.last_show_tuple)
+                        self.last_state, self.last_show_tuple, self.last_filename)
         finally:
             notifier.stop()
             self.msg.info('Tracker has stopped.')

--- a/trackma/tracker/tracker.py
+++ b/trackma/tracker/tracker.py
@@ -19,13 +19,23 @@ from __future__ import annotations
 import os
 import threading
 import time
+from collections.abc import Callable
+from typing import Any
 
 from trackma import utils
 from trackma.messenger import Messenger
 from trackma.parser import get_parser_class
 
+ShowTuple = tuple[dict[str, Any], int]
+TrackerState = utils.Tracker
+TrackerResolution = tuple[TrackerState, ShowTuple | None]
+ResolvePlayingShowCallback = Callable[[str | None], TrackerResolution]
+OnStateCallback = Callable[[TrackerState, ShowTuple | None, str | None], None]
+OnPlaybackCallback = Callable[[bool], None]
+OnTickCallback = Callable[[float | None], None]
 
-class TrackerBase(object):
+
+class TrackerBase:
     msg: Messenger
     active = True
     list = None
@@ -34,7 +44,7 @@ class TrackerBase(object):
     last_state = utils.Tracker.NOVIDEO
     last_time: int | float = 0
     last_updated = False
-    last_close_queue = None
+    last_close_queue: Callable[[], None] | None = None
     timer = None
 
     name = 'Tracker'
@@ -77,7 +87,7 @@ class TrackerBase(object):
         """Changes the message handler function on the fly."""
         self.msg = message_handler.with_classname(self.name)
 
-    def disable(self):
+    def disable(self) -> None:
         self.msg.info('Unloading...')
         self.active = False
 
@@ -90,7 +100,7 @@ class TrackerBase(object):
         except KeyError:
             raise utils.EngineFatal("Invalid signal.")
 
-    def observe(self, _config, _watch_dirs, /):
+    def observe(self, _config, _watch_dirs, /) -> None:
         raise NotImplementedError
 
     def get_status(self):
@@ -111,7 +121,7 @@ class TrackerBase(object):
         except KeyError:
             raise Exception("Call to undefined signal.")
 
-    def update_timer(self, state=None, show_tuple=None):
+    def update_timer(self, state: TrackerState | None = None, show_tuple: ShowTuple | None = None) -> None:
         if self.timer_paused:
             return
 
@@ -132,27 +142,27 @@ class TrackerBase(object):
             # Perform show update
             self.last_updated = True
 
-            def action(state=state):
+            def emit_update() -> None:
                 (show, episode) = show_tuple
                 if state == utils.Tracker.PLAYING:
-                    return self._emit_signal('update', show, episode)
+                    self._emit_signal('update', show, episode)
                 elif state == utils.Tracker.NOT_FOUND:
-                    return self._emit_signal('unrecognised', show, episode)
+                    self._emit_signal('unrecognised', show, episode)
 
             if self.config['tracker_update_close']:
                 self.msg.info('Waiting for the player to close.')
-                self.last_close_queue = action
+                self.last_close_queue = emit_update
             else:
-                action()
+                emit_update()
 
-    def _ignore_current(self):
+    def _ignore_current(self) -> None:
         # Stops attempt to update current episode
         self.last_updated = True
         self.last_state = utils.Tracker.IGNORED
         self.timer = None
         self._emit_signal('state', self.get_status())
 
-    def _update_state(self, state):
+    def _update_state(self, state: TrackerState) -> None:
         # Call when show or state is changed. Perform queued update if any.
         if self.last_close_queue:
             self.last_close_queue()
@@ -170,20 +180,20 @@ class TrackerBase(object):
                 self._emit_signal(
                     'playing', last_show['id'], False, last_show_ep)
 
-    def pause_timer(self):
+    def pause_timer(self) -> None:
         if not self.timer_paused:
             self.timer_paused = time.time()
 
             self._emit_signal('state', self.get_status())
 
-    def resume_timer(self):
+    def resume_timer(self) -> None:
         if self.timer_paused:
             self.timer_offset += time.time() - self.timer_paused
             self.timer_paused = None
 
             self._emit_signal('state', self.get_status())
 
-    def update_show_if_needed(self, state, show_tuple, filename=None):
+    def update_show_if_needed(self, state: TrackerState, show_tuple: ShowTuple, filename: str | None = None):
         self.last_filename = filename
 
         # If the state and show are unchanged, skip to countdown
@@ -246,7 +256,7 @@ class TrackerBase(object):
         self.last_state = state
         self._emit_signal('state', self.get_status())
 
-    def resolve_playing_show(self, filename):
+    def resolve_playing_show(self, filename: str) -> TrackerResolution:
         if not self.active:
             # Don't do anything if the Tracker is disabled
             return (utils.Tracker.NOVIDEO, None)

--- a/trackma/tracker/tracker.py
+++ b/trackma/tracker/tracker.py
@@ -26,13 +26,12 @@ from trackma import utils
 from trackma.messenger import Messenger
 from trackma.parser import get_parser_class
 
-TrackerState = utils.Tracker
 OnPlaybackCallback = Callable[[bool], None]
 OnTickCallback = Callable[[float | None], None]
 
 
 class TrackerResolution(NamedTuple):
-    state: TrackerState
+    state: utils.Tracker
     show: dict[str, Any] | None
     show_ep: int | None
 
@@ -144,7 +143,8 @@ class TrackerBase:
             return
 
         resolution = resolution or self.last_resolution
-        if not resolution or not resolution.show or resolution.show_ep is None:
+        if not resolution or not resolution.show or resolution.show_ep is None or resolution.state != utils.Tracker.PLAYING:
+            self.timer = None
             return
 
         self.timer = int(
@@ -170,13 +170,6 @@ class TrackerBase:
                 self.last_close_queue = emit_update
             else:
                 emit_update()
-
-    def _ignore_current(self) -> None:
-        # Stops attempt to update current episode
-        self.last_updated = True
-        self.last_state = utils.Tracker.IGNORED
-        self.timer = None
-        self._emit_signal('state', self.get_status())
 
     def _prepare_state_change(self) -> None:
         # Call when show or state is changed. Perform queued update if any.
@@ -226,26 +219,9 @@ class TrackerBase:
             self._prepare_state_change()
             # There's a new show/ep detected, so let's save the show information
             self.last_resolution = resolution
-            self.last_updated = False
+            self.last_updated = False  # TODO do we need to set this to True if IGNORED?
             if resolution.state == utils.Tracker.PLAYING:
                 self._emit_signal('playing', show['id'], True, episode)
-                # Check if we shouldn't update the show
-                expected_next_ep = show['my_progress'] + 1
-                if self.config['tracker_ignore_not_next'] and episode != expected_next_ep:
-                    self.msg.warn(
-                        'Not playing the next episode of {} (expected: {}, found: {}). Ignoring.'
-                            .format(show['title'], expected_next_ep, episode),
-                    )
-                    self._ignore_current()
-                    return
-                if episode == show['my_progress']:
-                    self.msg.warn('Playing the current episode of %s. Ignoring.' % show['title'])
-                    self._ignore_current()
-                    return
-                if episode < 1 or (show['total'] and episode > show['total']):
-                    self.msg.warn('Playing an invalid episode of %s. Ignoring.' % show['title'])
-                    self._ignore_current()
-                    return
 
             # Start our countdown
             if resolution.state == utils.Tracker.PLAYING:
@@ -308,7 +284,11 @@ class TrackerBase:
                 self.msg.debug("Redirected to: {} - {}".format(redirected_show, redirected_ep))
                 (playing_show, show_ep) = (redirected_show, redirected_ep)
 
-            return TrackerResolution(utils.Tracker.PLAYING, playing_show, show_ep)
+            state = utils.Tracker.PLAYING
+            if self._should_ignore(playing_show, show_ep):
+                state = utils.Tracker.IGNORED
+            return TrackerResolution(state, playing_show, show_ep)
+
         else:
             # Show not in list
             if self.config['tracker_not_found_prompt']:
@@ -317,3 +297,20 @@ class TrackerBase:
                 return TrackerResolution(utils.Tracker.NOT_FOUND, show, show_ep)
             else:
                 return TrackerResolution(utils.Tracker.NOT_FOUND, None, None)
+
+    def _should_ignore(self, playing_show: Any, show_ep: int) -> bool:
+        expected_ep = playing_show['my_progress'] + 1
+        title = playing_show['title']
+        if show_ep == playing_show['my_progress']:
+            self.msg.warn(f"Playing the current episode of {title}. Ignoring.")
+            return True
+        elif show_ep < 1 or (playing_show['total'] and show_ep > playing_show['total']):
+            self.msg.warn(f"Playing an invalid episode of {title}. Ignoring.")
+            return True
+        elif self.config['tracker_ignore_not_next'] and show_ep != expected_ep:
+            self.msg.warn(
+                f'Not playing the next episode of {title}'
+                f' (expected: {expected_ep}, found: {show_ep}). Ignoring.',
+            )
+            return True
+        return False

--- a/trackma/tracker/tracker.py
+++ b/trackma/tracker/tracker.py
@@ -111,11 +111,14 @@ class TrackerBase(object):
         except KeyError:
             raise Exception("Call to undefined signal.")
 
-    def update_timer(self, state, show_tuple):
+    def update_timer(self, state=None, show_tuple=None):
         if self.timer_paused:
             return
 
-        (show, episode) = show_tuple
+        show_tuple = show_tuple or self.last_show_tuple
+        state = state or self.last_state
+        if not show_tuple or not state:
+            return
 
         self.timer = int(
             1
@@ -130,6 +133,7 @@ class TrackerBase(object):
             self.last_updated = True
 
             def action(state=state):
+                (show, episode) = show_tuple
                 if state == utils.Tracker.PLAYING:
                     return self._emit_signal('update', show, episode)
                 elif state == utils.Tracker.NOT_FOUND:

--- a/trackma/tracker/tracker.py
+++ b/trackma/tracker/tracker.py
@@ -14,13 +14,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
+
 import os
 import threading
 import time
 
 from trackma import utils
-from trackma.parser import get_parser_class
 from trackma.messenger import Messenger
+from trackma.parser import get_parser_class
 
 
 class TrackerBase(object):
@@ -30,7 +32,7 @@ class TrackerBase(object):
     last_show_tuple = None
     last_filename = None
     last_state = utils.Tracker.NOVIDEO
-    last_time = 0
+    last_time: int | float = 0
     last_updated = False
     last_close_queue = None
     timer = None
@@ -88,7 +90,7 @@ class TrackerBase(object):
         except KeyError:
             raise utils.EngineFatal("Invalid signal.")
 
-    def observe(self, config, watch_dirs):
+    def observe(self, _config, _watch_dirs, /):
         raise NotImplementedError
 
     def get_status(self):
@@ -103,8 +105,9 @@ class TrackerBase(object):
 
     def _emit_signal(self, signal, *args):
         try:
-            if self.signals[signal]:
-                self.signals[signal](*args)
+            callback = self.signals[signal]
+            if callback is not None:
+                callback(*args)
         except KeyError:
             raise Exception("Call to undefined signal.")
 
@@ -176,7 +179,9 @@ class TrackerBase(object):
 
             self._emit_signal('state', self.get_status())
 
-    def update_show_if_needed(self, state, show_tuple):
+    def update_show_if_needed(self, state, show_tuple, filename=None):
+        self.last_filename = filename
+
         # If the state and show are unchanged, skip to countdown
         if show_tuple and state == self.last_state and show_tuple == self.last_show_tuple and not self.last_updated:
             self.update_timer(state, show_tuple)
@@ -226,7 +231,7 @@ class TrackerBase(object):
                     self.msg.info('Player was closed before update.')
             # There's a new video playing but the regex didn't recognize the format
             elif state == utils.Tracker.UNRECOGNIZED:
-                self.msg.warn('Found video but the file name format couldn\'t be recognized.')
+                self.msg.warn("Found video but the file name format couldn't be recognized.")
             elif state == utils.Tracker.NOT_FOUND:  # There's a new video playing but an associated show wasn't found
                 self.msg.warn('Found player but show not in list.')
 
@@ -237,17 +242,12 @@ class TrackerBase(object):
         self.last_state = state
         self._emit_signal('state', self.get_status())
 
-    def _get_playing_show(self, filename):
+    def resolve_playing_show(self, filename):
         if not self.active:
             # Don't do anything if the Tracker is disabled
             return (utils.Tracker.NOVIDEO, None)
 
         if filename:
-            if filename == self.last_filename:
-                # It's the exact same filename, there's no need to do the processing again
-                return (self.last_state, self.last_show_tuple)
-
-            self.last_filename = filename
             self.msg.debug("Guessing filename: {}".format(filename))
 
             # Trim out watch dir
@@ -284,5 +284,4 @@ class TrackerBase(object):
                 else:
                     return (utils.Tracker.NOT_FOUND, None)
         else:
-            self.last_filename = None
             return (utils.Tracker.NOVIDEO, None)  # Not playing

--- a/trackma/tracker/tracker.py
+++ b/trackma/tracker/tracker.py
@@ -178,7 +178,7 @@ class TrackerBase:
         self.timer = None
         self._emit_signal('state', self.get_status())
 
-    def _update_state(self, state: TrackerState) -> None:
+    def _prepare_state_change(self) -> None:
         # Call when show or state is changed. Perform queued update if any.
         if self.last_close_queue:
             self.last_close_queue()
@@ -223,7 +223,7 @@ class TrackerBase:
         show_tuple = resolution.show_tuple()
         if resolution != self.last_resolution and show_tuple:
             (show, episode) = show_tuple
-            self._update_state(resolution.state)
+            self._prepare_state_change()
             # There's a new show/ep detected, so let's save the show information
             self.last_resolution = resolution
             self.last_updated = False
@@ -255,7 +255,7 @@ class TrackerBase:
 
             self.update_timer(resolution)
         elif self.last_state != resolution.state:
-            self._update_state(resolution.state)
+            self._prepare_state_change()
 
             # React depending on state
             if resolution.state == utils.Tracker.NOVIDEO:  # No video is playing

--- a/trackma/tracker/tracker.py
+++ b/trackma/tracker/tracker.py
@@ -20,26 +20,44 @@ import os
 import threading
 import time
 from collections.abc import Callable
-from typing import Any
+from typing import Any, NamedTuple
 
 from trackma import utils
 from trackma.messenger import Messenger
 from trackma.parser import get_parser_class
 
-ShowTuple = tuple[dict[str, Any], int]
 TrackerState = utils.Tracker
-TrackerResolution = tuple[TrackerState, ShowTuple | None]
-ResolvePlayingShowCallback = Callable[[str | None], TrackerResolution]
-OnStateCallback = Callable[[TrackerState, ShowTuple | None, str | None], None]
 OnPlaybackCallback = Callable[[bool], None]
 OnTickCallback = Callable[[float | None], None]
+
+
+class TrackerResolution(NamedTuple):
+    state: TrackerState
+    show: dict[str, Any] | None
+    show_ep: int | None
+
+    @classmethod
+    def NO_VIDEO(cls) -> TrackerResolution:
+        return cls(utils.Tracker.NOVIDEO, None, None)
+
+    @classmethod
+    def UNRECOGNIZED(cls) -> TrackerResolution:
+        return cls(utils.Tracker.UNRECOGNIZED, None, None)
+
+    def show_tuple(self) -> tuple[dict[str, Any], int] | None:
+        if self.show is None or self.show_ep is None:
+            return None
+        return (self.show, self.show_ep)
+
+
+OnStateCallback = Callable[[TrackerResolution, str | None], None]
 
 
 class TrackerBase:
     msg: Messenger
     active = True
     list = None
-    last_show_tuple = None
+    last_resolution = None
     last_filename = None
     last_state = utils.Tracker.NOVIDEO
     last_time: int | float = 0
@@ -109,7 +127,7 @@ class TrackerBase:
             'timer': self.timer,
             'viewOffset': self.view_offset,
             'paused': bool(self.timer_paused),
-            'show': self.last_show_tuple,
+            'show': self.last_resolution.show_tuple() if self.last_resolution else None,
             'filename': self.last_filename,
         }
 
@@ -121,13 +139,12 @@ class TrackerBase:
         except KeyError:
             raise Exception("Call to undefined signal.")
 
-    def update_timer(self, state: TrackerState | None = None, show_tuple: ShowTuple | None = None) -> None:
+    def update_timer(self, resolution: TrackerResolution | None = None) -> None:
         if self.timer_paused:
             return
 
-        show_tuple = show_tuple or self.last_show_tuple
-        state = state or self.last_state
-        if not show_tuple or not state:
+        resolution = resolution or self.last_resolution
+        if not resolution or not resolution.show or resolution.show_ep is None:
             return
 
         self.timer = int(
@@ -143,11 +160,10 @@ class TrackerBase:
             self.last_updated = True
 
             def emit_update() -> None:
-                (show, episode) = show_tuple
-                if state == utils.Tracker.PLAYING:
-                    self._emit_signal('update', show, episode)
-                elif state == utils.Tracker.NOT_FOUND:
-                    self._emit_signal('unrecognised', show, episode)
+                if resolution.state == utils.Tracker.PLAYING:
+                    self._emit_signal('update', resolution.show, resolution.show_ep)
+                elif resolution.state == utils.Tracker.NOT_FOUND:
+                    self._emit_signal('unrecognised', resolution.show, resolution.show_ep)
 
             if self.config['tracker_update_close']:
                 self.msg.info('Waiting for the player to close.')
@@ -174,8 +190,11 @@ class TrackerBase:
         self.last_time = time.time()
 
         # Emit the new playing signal
-        if self.last_show_tuple:
-            (last_show, last_show_ep) = self.last_show_tuple
+        if self.last_resolution:
+            last_show = self.last_resolution.show
+            last_show_ep = self.last_resolution.show_ep
+            if not last_show or last_show_ep is None:
+                return
             if last_show['id']:
                 self._emit_signal(
                     'playing', last_show['id'], False, last_show_ep)
@@ -193,21 +212,22 @@ class TrackerBase:
 
             self._emit_signal('state', self.get_status())
 
-    def update_show_if_needed(self, state: TrackerState, show_tuple: ShowTuple, filename: str | None = None):
+    def update_show_if_needed(self, resolution: TrackerResolution, filename: str | None = None):
         self.last_filename = filename
 
         # If the state and show are unchanged, skip to countdown
-        if show_tuple and state == self.last_state and show_tuple == self.last_show_tuple and not self.last_updated:
-            self.update_timer(state, show_tuple)
+        if resolution == self.last_resolution and not self.last_updated:
+            self.update_timer(resolution)
             return
 
-        if show_tuple and show_tuple != self.last_show_tuple:
+        show_tuple = resolution.show_tuple()
+        if resolution != self.last_resolution and show_tuple:
             (show, episode) = show_tuple
-            self._update_state(state)
+            self._update_state(resolution.state)
             # There's a new show/ep detected, so let's save the show information
-            self.last_show_tuple = show_tuple
+            self.last_resolution = resolution
             self.last_updated = False
-            if state == utils.Tracker.PLAYING:
+            if resolution.state == utils.Tracker.PLAYING:
                 self._emit_signal('playing', show['id'], True, episode)
                 # Check if we shouldn't update the show
                 expected_next_ep = show['my_progress'] + 1
@@ -228,74 +248,72 @@ class TrackerBase:
                     return
 
             # Start our countdown
-            (show, episode) = show_tuple
-            if state == utils.Tracker.PLAYING:
+            if resolution.state == utils.Tracker.PLAYING:
                 self.msg.info('Will update %s - %d' % (show['title'], episode))
-            elif state == utils.Tracker.NOT_FOUND:
+            elif resolution.state == utils.Tracker.NOT_FOUND:
                 self.msg.info('Will add %s - %d' % (show['title'], episode))
 
-            self.update_timer(state, show_tuple)
-        elif self.last_state != state:
-            self._update_state(state)
+            self.update_timer(resolution)
+        elif self.last_state != resolution.state:
+            self._update_state(resolution.state)
 
             # React depending on state
-            if state == utils.Tracker.NOVIDEO:  # No video is playing
+            if resolution.state == utils.Tracker.NOVIDEO:  # No video is playing
                 # Video didn't get to update phase before it was closed
                 if self.last_state == utils.Tracker.PLAYING and not self.last_updated:
                     self.msg.info('Player was closed before update.')
             # There's a new video playing but the regex didn't recognize the format
-            elif state == utils.Tracker.UNRECOGNIZED:
+            elif resolution.state == utils.Tracker.UNRECOGNIZED:
                 self.msg.warn("Found video but the file name format couldn't be recognized.")
-            elif state == utils.Tracker.NOT_FOUND:  # There's a new video playing but an associated show wasn't found
+            elif resolution.state == utils.Tracker.NOT_FOUND:  # There's a new video playing but an associated show wasn't found
                 self.msg.warn('Found player but show not in list.')
 
-            self.last_show_tuple = None
+            self.last_resolution = None
             self.last_updated = False
             self.timer = None
 
-        self.last_state = state
+        self.last_state = resolution.state
         self._emit_signal('state', self.get_status())
 
-    def resolve_playing_show(self, filename: str) -> TrackerResolution:
+    def resolve_playing_show(self, filename: str | None) -> TrackerResolution:
         if not self.active:
             # Don't do anything if the Tracker is disabled
-            return (utils.Tracker.NOVIDEO, None)
+            return TrackerResolution.NO_VIDEO()
+        elif not filename:
+            return TrackerResolution.NO_VIDEO()
 
-        if filename:
-            self.msg.debug("Guessing filename: {}".format(filename))
+        self.msg.debug("Guessing filename: {}".format(filename))
 
-            # Trim out watch dir
-            if os.path.isabs(filename):
-                for watch_prefix in self.watch_dirs:
-                    if filename.startswith(watch_prefix):
-                        filename = filename[len(watch_prefix):].lstrip(os.path.sep)
-                        break
+        # Trim out watch dir
+        if os.path.isabs(filename):
+            for watch_prefix in self.watch_dirs:
+                if filename.startswith(watch_prefix):
+                    filename = filename[len(watch_prefix):].lstrip(os.path.sep)
+                    break
 
-            # Invoke the parser to extract show title and episode.
-            aie = self.parser_class(self.msg, filename)
-            (show_title, show_ep) = (aie.getName(), aie.getEpisode())
-            if not show_title:
-                # Format not recognized
-                return (utils.Tracker.UNRECOGNIZED, None)
+        # Invoke the parser to extract show title and episode.
+        aie = self.parser_class(self.msg, filename)
+        (show_title, show_ep) = (aie.getName(), aie.getEpisode())
+        if not show_title:
+            # Format not recognized
+            return TrackerResolution.UNRECOGNIZED()
 
-            playing_show = utils.guess_show(show_title, self.list)
-            self.msg.debug("Show guess: {}: {} - {}".format(show_title, playing_show, show_ep))
+        playing_show = utils.guess_show(show_title, self.list)
+        self.msg.debug("Show guess: {}: {} - {}".format(show_title, playing_show, show_ep))
 
-            if playing_show:
-                (redirected_show, redirected_ep) = utils.redirect_show(
-                    (playing_show, show_ep), self.redirections, self.list)
-                if (redirected_show, redirected_ep) != (playing_show, show_ep):
-                    self.msg.debug("Redirected to: {} - {}".format(redirected_show, redirected_ep))
-                    (playing_show, show_ep) = (redirected_show, redirected_ep)
+        if playing_show:
+            (redirected_show, redirected_ep) = utils.redirect_show(
+                (playing_show, show_ep), self.redirections, self.list)
+            if (redirected_show, redirected_ep) != (playing_show, show_ep):
+                self.msg.debug("Redirected to: {} - {}".format(redirected_show, redirected_ep))
+                (playing_show, show_ep) = (redirected_show, redirected_ep)
 
-                return (utils.Tracker.PLAYING, (playing_show, show_ep))
-            else:
-                # Show not in list
-                if self.config['tracker_not_found_prompt']:
-                    # Dummy show to search for
-                    show = {'id': 0, 'title': show_title}
-                    return (utils.Tracker.NOT_FOUND, (show, show_ep))
-                else:
-                    return (utils.Tracker.NOT_FOUND, None)
+            return TrackerResolution(utils.Tracker.PLAYING, playing_show, show_ep)
         else:
-            return (utils.Tracker.NOVIDEO, None)  # Not playing
+            # Show not in list
+            if self.config['tracker_not_found_prompt']:
+                # Dummy show to search for
+                show = {'id': 0, 'title': show_title}
+                return TrackerResolution(utils.Tracker.NOT_FOUND, show, show_ep)
+            else:
+                return TrackerResolution(utils.Tracker.NOT_FOUND, None, None)

--- a/trackma/tracker/win32.py
+++ b/trackma/tracker/win32.py
@@ -79,8 +79,8 @@ class Win32Tracker(tracker.TrackerBase):
         while self.active:
             # This runs the tracker and update the playing show if necessary
             filename = self._get_playing_file_win32()
-            (state, show_tuple) = self._get_playing_show(filename)
-            self.update_show_if_needed(state, show_tuple)
+            (state, show_tuple) = self.resolve_playing_show(filename)
+            self.update_show_if_needed(state, show_tuple, filename)
 
             # Wait for the interval before running check again
             time.sleep(1)

--- a/trackma/tracker/win32.py
+++ b/trackma/tracker/win32.py
@@ -18,10 +18,10 @@ import ctypes
 import re
 import time
 
-from trackma.tracker import tracker
+from .tracker import TrackerBase, TrackerResolution
 
 
-class Win32Tracker(tracker.TrackerBase):
+class Win32Tracker(TrackerBase):
     name = 'Tracker (win32)'
 
     def __init__(self, messenger, tracker_list, config, watch_dirs, redirections=None):
@@ -79,7 +79,8 @@ class Win32Tracker(tracker.TrackerBase):
         while self.active:
             # This runs the tracker and update the playing show if necessary
             filename = self._get_playing_file_win32()
-            (state, show_tuple) = self.resolve_playing_show(filename)
+            resolution: TrackerResolution = self.resolve_playing_show(filename)
+            state, show_tuple = resolution
             self.update_show_if_needed(state, show_tuple, filename)
 
             # Wait for the interval before running check again

--- a/trackma/tracker/win32.py
+++ b/trackma/tracker/win32.py
@@ -18,7 +18,7 @@ import ctypes
 import re
 import time
 
-from .tracker import TrackerBase, TrackerResolution
+from .tracker import TrackerBase
 
 
 class Win32Tracker(TrackerBase):
@@ -79,9 +79,8 @@ class Win32Tracker(TrackerBase):
         while self.active:
             # This runs the tracker and update the playing show if necessary
             filename = self._get_playing_file_win32()
-            resolution: TrackerResolution = self.resolve_playing_show(filename)
-            state, show_tuple = resolution
-            self.update_show_if_needed(state, show_tuple, filename)
+            resolution = self.resolve_playing_show(filename)
+            self.update_show_if_needed(resolution, filename)
 
             # Wait for the interval before running check again
             time.sleep(1)


### PR DESCRIPTION
What started out as a simple idea for decoupling mpris dbus and the tracker state & logic turned out to become a slightly larger refactoring on the whole tracker architecture that ended up fixing two not really important but long-standing issues I had noticed with the mpris tracker over the past months where it would be spamming a lot of state changes in the debug log when the *relevant* state really didn't change much.

In the end, I spent quite a bit of time for relatively little gain, but I would still say that the code is now in a much better state to reason about and the added type annotations will also help in the long run.